### PR TITLE
new plugins: sleep, always_reclaim, interdict, and run_command

### DIFF
--- a/docs/fork_changes.md
+++ b/docs/fork_changes.md
@@ -1,0 +1,83 @@
+# Changes to the fork branch
+
+This branch adds new plugins and makes small changes to the oomd engine
+to complement them.  The new plugins are: sleep, always_reclaim, interdict,
+and run_command.  The engine now supports an exit registry where plugins
+can add functions to run at oomd exit, and an always-continue flag to
+always run a ruleset's actions which may behave differently when detectors
+fail to match.
+
+# Plugins
+
+## sleep
+
+### Arguments
+
+    duration (in seconds)
+
+### Description
+
+This plugin allows an action to occur periodically at an interval greater
+than the duration of the event loop, especially for use with `always_reclaim`.
+
+CONTINUE if more than `duration` seconds have elapsed since the last
+CONTINUE, otherwise STOP.
+
+## always_reclaim
+
+### Arguments
+
+    cgroup
+    reclaim_bytes
+
+This plugin launches a reclamation of `reclaim_bytes` for the cgroup(s)
+specified in `cgroup`.  Reclamation consists of a write to the
+`memory.reclaim` file of the cgroup.  The plugin always returns CONTINUE.
+
+### Description
+
+## interdict
+
+### Arguments
+
+    cgroup
+    memhigh_pct (from 1 to 99)
+
+### Description
+
+This plugin toggles a cgroup's `memory.high` limit between its current
+value and a reduced value.  The intent is, under sufficient memory
+contention, to encumber low-priority cgroups enough that the kernel
+throttles further memory allocations.  Once the contention subsides,
+the cgroup is unencumbered.  NB. the ruleset must specify
+`"always-continue": true` for the plugin to operate correctly.
+
+When all detectors return CONTINUE, this plugin writes a value to
+the cgroup `memory.high` file that is `memhigh_pct` percentage of the
+value in `memory.current` and saves the prior value from `memory.high`.
+If a detector returns STOP, the plugin writes the saved value back to
+`memory.high`.  The plugin always returns CONTINUE.  At oomd exit,
+all saved values are written back.
+
+## run_command
+
+### Arguments
+
+    command
+    argument
+    use_exit_value
+    cache_sec
+    timeout_msec
+
+### Description
+
+This plugin runs `command` with optional `argument` in which multiple
+arguments may be specified by separating them with a tab (`\t`).
+If `use_exit_value` is true, then the plugin returns CONTINUE for a
+0 exit value and STOP otherwise.  If `use_exit_value` is false, the
+default, then the plugin returns CONTINUE.
+
+If `cache_sec`, default 0, is greater than 0 then the plugin returns
+the value from the last run for the duration specified.  If `timeout_msec`,
+default 500 milliseconds, is greater than 0, then a run exceeding the
+timeout is killed.  With `use_exit_value` true, a killed run returns STOP.

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@ project('oomd', 'cpp',
   version : 'v0.5.0',
   meson_version : '>= 0.45',
   license : 'GPL2',
-  default_options : ['stdsplit=false', 'cpp_std=c++20'])
+  default_options : ['stdsplit=false', 'cpp_std=c++17'])
 
 cpp_args = ['-DMESON_BUILD']
 

--- a/meson.build
+++ b/meson.build
@@ -62,6 +62,7 @@ srcs = files('''
     src/oomd/plugins/Sleep.cpp
     src/oomd/plugins/AlwaysReclaim.cpp
     src/oomd/plugins/Interdict.cpp
+    src/oomd/plugins/RunCommand.cpp
     src/oomd/util/Fs.cpp
     src/oomd/util/Util.cpp
     src/oomd/util/PluginArgParser.cpp

--- a/meson.build
+++ b/meson.build
@@ -29,6 +29,7 @@ srcs = files('''
     src/oomd/Stats.cpp
     src/oomd/StatsClient.cpp
     src/oomd/PluginRegistry.cpp
+    src/oomd/ExitRegistry.cpp
     src/oomd/config/ConfigCompiler.cpp
     src/oomd/config/ConfigTypes.cpp
     src/oomd/config/JsonConfigParser.cpp
@@ -60,6 +61,7 @@ srcs = files('''
     src/oomd/plugins/KillPressure.cpp
     src/oomd/plugins/Sleep.cpp
     src/oomd/plugins/AlwaysReclaim.cpp
+    src/oomd/plugins/Interdict.cpp
     src/oomd/util/Fs.cpp
     src/oomd/util/Util.cpp
     src/oomd/util/PluginArgParser.cpp

--- a/meson.build
+++ b/meson.build
@@ -58,6 +58,8 @@ srcs = files('''
     src/oomd/plugins/KillSwapUsage.cpp
     src/oomd/plugins/KillPgScan.cpp
     src/oomd/plugins/KillPressure.cpp
+    src/oomd/plugins/Sleep.cpp
+    src/oomd/plugins/AlwaysReclaim.cpp
     src/oomd/util/Fs.cpp
     src/oomd/util/Util.cpp
     src/oomd/util/PluginArgParser.cpp

--- a/src/oomd/ExitRegistry.cpp
+++ b/src/oomd/ExitRegistry.cpp
@@ -1,0 +1,10 @@
+#include "ExitRegistry.h"
+
+namespace Oomd {
+
+ExitRegistry& getExitRegistry() {
+  static ExitRegistry r;
+  return r;
+}
+
+} // namespace Oomd

--- a/src/oomd/ExitRegistry.h
+++ b/src/oomd/ExitRegistry.h
@@ -1,0 +1,35 @@
+#include <functional>
+#include <string>
+#include <unordered_map>
+
+namespace Oomd {
+
+class ExitRegistry {
+ public:
+  using ExitFunction = std::function<void()>;
+  using ExitMap = std::unordered_map<std::string, ExitFunction>;
+
+  bool add(const std::string& name, ExitFunction f) {
+    if (map_.find(name) != map_.end()) {
+      return false;
+    }
+
+    map_[name] = f;
+    return true;
+  }
+
+  void callHooks() {
+    for (auto const& data : map_)
+      data.second();
+  }
+
+ private:
+  ExitMap map_;
+};
+
+ExitRegistry& getExitRegistry();
+
+#define REGISTER_EXIT_HOOK(hook_name, exit_func) \
+  getExitRegistry().add(#hook_name, (exit_func))
+
+} // namespace Oomd

--- a/src/oomd/Oomd.cpp
+++ b/src/oomd/Oomd.cpp
@@ -29,6 +29,7 @@
 #include "oomd/include/Defines.h"
 #include "oomd/util/Fs.h"
 #include "oomd/util/Util.h"
+#include "oomd/ExitRegistry.h"
 namespace Oomd {
 
 Oomd::Oomd(
@@ -136,6 +137,7 @@ int Oomd::run(const sigset_t* mask) {
     } else if (rc != -1) {
       // Synchronously log to stderr so there's no buffering
       std::cerr << "Received signal " << rc << ". Exiting!";
+      getExitRegistry().callHooks();
       pthread_sigmask(SIG_UNBLOCK, mask, nullptr);
       pthread_kill(pthread_self(), rc);
       return -1;

--- a/src/oomd/Oomd.cpp
+++ b/src/oomd/Oomd.cpp
@@ -23,13 +23,13 @@
 #include <thread>
 
 #include "oomd/CgroupContext.h"
+#include "oomd/ExitRegistry.h"
 #include "oomd/Log.h"
 #include "oomd/dropin/FsDropInService.h"
 #include "oomd/include/Assert.h"
 #include "oomd/include/Defines.h"
 #include "oomd/util/Fs.h"
 #include "oomd/util/Util.h"
-#include "oomd/ExitRegistry.h"
 namespace Oomd {
 
 Oomd::Oomd(

--- a/src/oomd/config/ConfigCompiler.cpp
+++ b/src/oomd/config/ConfigCompiler.cpp
@@ -186,6 +186,7 @@ std::unique_ptr<Oomd::Engine::Ruleset> compileRuleset(
       ruleset.dropin.disable_on_drop_in,
       ruleset.dropin.detectorgroups_enabled,
       ruleset.dropin.actiongroup_enabled,
+      ruleset.always_continue,
       silenced_logs,
       post_action_delay,
       prekill_hook_timeout,

--- a/src/oomd/config/ConfigCompilerTest.cpp
+++ b/src/oomd/config/ConfigCompilerTest.cpp
@@ -397,6 +397,34 @@ TEST_F(CompilerTest, MultiGroupIncrementCount) {
   EXPECT_EQ(count, 6);
 }
 
+// redo the last test but with always_continue=true
+TEST_F(CompilerTest, AlwaysContinueIncrementCount) {
+  IR::Detector cont;
+  cont.name = "Continue";
+  IR::Detector stop;
+  stop.name = "Stop";
+  IR::Action increment;
+  increment.name = "IncrementCount";
+  IR::DetectorGroup dgroup1{"group1", {cont}};
+  IR::DetectorGroup dgroup2{"group2", {stop}};
+  IR::DetectorGroup dgroup3{"group3", {cont}};
+  IR::Ruleset ruleset1{"ruleset1", {dgroup1}, {increment}, {}, "", "", ""};
+  IR::Ruleset ruleset2{"ruleset2", {dgroup2}, {increment}, {}, "", "", ""};
+  ruleset2.always_continue = true;
+  IR::Ruleset ruleset3{"ruleset3", {dgroup3}, {increment}, {}, "", "", ""};
+  root.rulesets.emplace_back(std::move(ruleset1));
+  root.rulesets.emplace_back(std::move(ruleset2));
+  root.rulesets.emplace_back(std::move(ruleset3));
+
+  auto engine = compile();
+  ASSERT_TRUE(engine);
+  for (int i = 0; i < 3; ++i) {
+    engine->runOnce(context);
+  }
+
+  EXPECT_EQ(count, 9);
+}
+
 TEST_F(CompilerTest, AsyncAction) {
   IR::Action cont{IR::Plugin{.name = "Continue"}};
   IR::Action inc{IR::Plugin{.name = "IncrementCount"}};

--- a/src/oomd/config/ConfigTypes.cpp
+++ b/src/oomd/config/ConfigTypes.cpp
@@ -83,6 +83,8 @@ void dumpIR(const Root& root) {
          << "PrekillHookTimeout=" << ruleset.prekill_hook_timeout;
     OLOG << getIndentSpaces(indent) << "XattrFilter=" << ruleset.xattr_filter;
     OLOG << getIndentSpaces(indent) << "Cgroup=" << ruleset.cgroup;
+    OLOG << getIndentSpaces(indent)
+         << "AlwaysContinue=" << ruleset.always_continue;
 
     // Print DetectorGroup's
     for (const auto& dg : ruleset.dgs) {

--- a/src/oomd/config/ConfigTypes.h
+++ b/src/oomd/config/ConfigTypes.h
@@ -69,12 +69,12 @@ struct Ruleset {
   std::vector<DetectorGroup> dgs;
   std::vector<Action> acts;
   DropIn dropin;
-  bool always_continue{false};
   std::string silence_logs;
   std::string post_action_delay;
   std::string prekill_hook_timeout;
   std::string xattr_filter;
   std::string cgroup;
+  bool always_continue{false};
 };
 
 struct Root {

--- a/src/oomd/config/ConfigTypes.h
+++ b/src/oomd/config/ConfigTypes.h
@@ -69,6 +69,7 @@ struct Ruleset {
   std::vector<DetectorGroup> dgs;
   std::vector<Action> acts;
   DropIn dropin;
+  bool always_continue{false};
   std::string silence_logs;
   std::string post_action_delay;
   std::string prekill_hook_timeout;

--- a/src/oomd/config/JsonConfigParser.cpp
+++ b/src/oomd/config/JsonConfigParser.cpp
@@ -111,6 +111,8 @@ Oomd::Config2::IR::Ruleset parseRuleset(const Json::Value& ruleset) {
 
   ir_ruleset.dropin = parseDropIn(ruleset.get("drop-in", {}));
 
+  ir_ruleset.always_continue = ruleset.get("always-continue", false).asBool();
+
   ir_ruleset.silence_logs = ruleset.get("silence-logs", {}).asString();
 
   ir_ruleset.post_action_delay =

--- a/src/oomd/engine/Ruleset.cpp
+++ b/src/oomd/engine/Ruleset.cpp
@@ -158,7 +158,7 @@ uint32_t Ruleset::runOnce(OomdContext& context) {
         continue;
       }
     }
-    if (!runnable_rulesets_.contains(cgroup.absolutePath())) {
+    if (!runnable_rulesets_.count(cgroup.absolutePath())) {
       OLOG << "Adding runnable ruleset for cgroup: " << cgroup.absolutePath();
       registerRunnableRulesetForCgroupPath(context, cgroup);
     }
@@ -169,7 +169,7 @@ uint32_t Ruleset::runOnce(OomdContext& context) {
   for (auto&& cgroup_it = runnable_rulesets_.begin();
        cgroup_it != runnable_rulesets_.end();
        ++cgroup_it) {
-    if (visited.contains(cgroup_it->first)) {
+    if (visited.count(cgroup_it->first)) {
       continue;
     }
     OLOG << "Dropping runnable ruleset for cgroup: " << cgroup_it->first;

--- a/src/oomd/engine/Ruleset.cpp
+++ b/src/oomd/engine/Ruleset.cpp
@@ -32,6 +32,7 @@ Ruleset::Ruleset(
     bool disable_on_drop_in,
     bool detectorgroups_dropin_enabled,
     bool actiongroup_dropin_enabled,
+    bool always_continue,
     uint32_t silence_logs,
     int post_action_delay,
     int prekill_hook_timeout,
@@ -46,6 +47,7 @@ Ruleset::Ruleset(
       disable_on_drop_in_(disable_on_drop_in),
       detectorgroups_dropin_enabled_(detectorgroups_dropin_enabled),
       actiongroup_dropin_enabled_(actiongroup_dropin_enabled),
+      always_continue_(always_continue),
       silenced_logs_(silence_logs),
       xattr_filter_(xattr_filter) {
   if (!cgroup.empty()) {
@@ -61,6 +63,7 @@ Ruleset::Ruleset(
     bool disable_on_drop_in,
     bool detectorgroups_dropin_enabled,
     bool actiongroup_dropin_enabled,
+    bool always_continue,
     uint32_t silence_logs,
     int post_action_delay,
     int prekill_hook_timeout,
@@ -73,6 +76,7 @@ Ruleset::Ruleset(
       disable_on_drop_in_(disable_on_drop_in),
       detectorgroups_dropin_enabled_(detectorgroups_dropin_enabled),
       actiongroup_dropin_enabled_(actiongroup_dropin_enabled),
+      always_continue_(always_continue),
       silenced_logs_(silence_logs) {
   cgroup_ = std::move(cgroup);
 }
@@ -240,7 +244,7 @@ uint32_t Ruleset::runOnceImpl(OomdContext& context) {
     }
   }
 
-  if (!run_actions) {
+  if (!run_actions && !always_continue_) {
     return 0;
   }
 
@@ -347,6 +351,7 @@ void Ruleset::registerRunnableRulesetForCgroupPath(
       disable_on_drop_in_,
       detectorgroups_dropin_enabled_,
       actiongroup_dropin_enabled_,
+      always_continue_,
       silenced_logs_,
       post_action_delay_,
       prekill_hook_timeout_,

--- a/src/oomd/engine/Ruleset.h
+++ b/src/oomd/engine/Ruleset.h
@@ -38,6 +38,7 @@ class Ruleset {
       bool disable_on_drop_in = false,
       bool detectorgroups_dropin_enabled = false,
       bool actiongroup_dropin_enabled = false,
+      bool always_continue = false,
       uint32_t silenced_logs = 0,
       int post_action_delay = DEFAULT_POST_ACTION_DELAY,
       int prekill_hook_timeout = DEFAULT_PREKILL_HOOK_TIMEOUT,
@@ -51,6 +52,7 @@ class Ruleset {
       bool disable_on_drop_in,
       bool detectorgroups_dropin_enabled,
       bool actiongroup_dropin_enabled,
+      bool always_continue,
       uint32_t silenced_logs,
       int post_action_delay,
       int prekill_hook_timeout,
@@ -110,6 +112,7 @@ class Ruleset {
   bool disable_on_drop_in_{false};
   bool detectorgroups_dropin_enabled_{false};
   bool actiongroup_dropin_enabled_{false};
+  bool always_continue_{false};
   uint32_t silenced_logs_{0};
   int32_t numTargeted_{0};
   std::string xattr_filter_;

--- a/src/oomd/include/CgroupPathTest.cpp
+++ b/src/oomd/include/CgroupPathTest.cpp
@@ -22,6 +22,7 @@
 
 #include "oomd/include/CgroupPath.h"
 #include "oomd/util/Fixture.h"
+#include "oomd/util/ScopeGuard.h"
 
 using namespace Oomd;
 
@@ -107,6 +108,9 @@ TEST(CgroupPathTest, HashTest) {
 TEST(CgroupPathTest, ResolveWildcardTest) {
   using F = Fixture;
   auto tempDir = F::mkdtempChecked();
+  OOMD_SCOPE_EXIT {
+    F::rmrChecked(tempDir);
+  };
   auto [name, fixture] = F::makeDir(
       "wildcard_root",
       {F::makeFile("a.txt", "content of a\n"),

--- a/src/oomd/plugins/AlwaysReclaim.cpp
+++ b/src/oomd/plugins/AlwaysReclaim.cpp
@@ -26,13 +26,12 @@ int AlwaysReclaim::init(
   return 0;
 }
 
-void AlwaysReclaim::reclaim_one(
-    const CgroupContext& target) {
+void AlwaysReclaim::reclaim_one(const CgroupContext& target) {
   auto ok = Fs::writeMemReclaimAt(target.fd(), reclaim_bytes_);
 
   std::ostringstream oss;
   oss << "cgroup=" << target.cgroup().relativePath()
-      << " reclaim_bytes=" << reclaim_bytes_ << " ok=" << (bool) ok;
+      << " reclaim_bytes=" << reclaim_bytes_ << " ok=" << (bool)ok;
   OLOG << oss.str();
 }
 

--- a/src/oomd/plugins/AlwaysReclaim.cpp
+++ b/src/oomd/plugins/AlwaysReclaim.cpp
@@ -17,7 +17,7 @@ int AlwaysReclaim::init(
         return PluginArgParser::parseCgroup(context, cgroupStr);
       },
       true);
-  argParser_.addArgument("reclaim_bytes", reclaim_bytes_);
+  argParser_.addArgument("reclaim_bytes", reclaim_bytes_, true);
 
   if (!argParser_.parse(args)) {
     return 1;

--- a/src/oomd/plugins/AlwaysReclaim.cpp
+++ b/src/oomd/plugins/AlwaysReclaim.cpp
@@ -1,0 +1,46 @@
+#include "oomd/plugins/AlwaysReclaim.h"
+
+#include "oomd/Log.h"
+#include "oomd/PluginRegistry.h"
+
+namespace Oomd {
+
+REGISTER_PLUGIN(always_reclaim, AlwaysReclaim::create);
+
+int AlwaysReclaim::init(
+    const Engine::PluginArgs& args,
+    const PluginConstructionContext& context) {
+  argParser_.addArgumentCustom(
+      "cgroup",
+      cgroups_,
+      [context](const std::string& cgroupStr) {
+        return PluginArgParser::parseCgroup(context, cgroupStr);
+      },
+      true);
+  argParser_.addArgument("reclaim_bytes", reclaim_bytes_);
+
+  if (!argParser_.parse(args)) {
+    return 1;
+  }
+
+  return 0;
+}
+
+void AlwaysReclaim::reclaim_one(
+    const CgroupContext& target) {
+  auto ok = Fs::writeMemReclaimAt(target.fd(), reclaim_bytes_);
+
+  std::ostringstream oss;
+  oss << "cgroup=" << target.cgroup().relativePath()
+      << " reclaim_bytes=" << reclaim_bytes_ << " ok=" << (bool) ok;
+  OLOG << oss.str();
+}
+
+Engine::PluginRet AlwaysReclaim::run(OomdContext& ctx) {
+  for (const auto& cgroupCtx : ctx.addToCacheAndGet(cgroups_))
+    reclaim_one(cgroupCtx);
+
+  return Engine::PluginRet::CONTINUE;
+}
+
+} // namespace Oomd

--- a/src/oomd/plugins/AlwaysReclaim.h
+++ b/src/oomd/plugins/AlwaysReclaim.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "oomd/engine/BasePlugin.h"
+
+namespace Oomd {
+
+class AlwaysReclaim : public Engine::BasePlugin {
+ public:
+  int init(
+      const Engine::PluginArgs& args,
+      const PluginConstructionContext& /* unused */) override;
+
+  Engine::PluginRet run(OomdContext& ctx) override;
+
+  static AlwaysReclaim* create() {
+    return new AlwaysReclaim();
+  }
+
+  ~AlwaysReclaim() = default;
+
+ private:
+  void reclaim_one(const Oomd::CgroupContext&);
+
+  std::unordered_set<CgroupPath> cgroups_;
+  int64_t reclaim_bytes_{0};
+};
+
+} // namespace Oomd

--- a/src/oomd/plugins/Interdict.cpp
+++ b/src/oomd/plugins/Interdict.cpp
@@ -1,0 +1,109 @@
+#include "oomd/plugins/Interdict.h"
+
+#include "oomd/Log.h"
+#include "oomd/PluginRegistry.h"
+#include "oomd/ExitRegistry.h"
+
+namespace Oomd {
+
+REGISTER_PLUGIN(interdict, Interdict::create);
+
+int Interdict::init(
+    const Engine::PluginArgs& args,
+    const PluginConstructionContext& context) {
+  argParser_.addArgumentCustom(
+      "cgroup",
+      cgroups_,
+      [context](const std::string& cgroupStr) {
+        return PluginArgParser::parseCgroup(context, cgroupStr);
+      },
+      true);
+  int64_t pct;
+  argParser_.addArgument("memhigh_pct", pct, true);
+
+  if (!argParser_.parse(args)) {
+    return 1;
+  }
+
+  if (pct < 1 || pct > 99) {
+    OLOG << "Percentage not between 0 and 100: " << pct;
+    return 1;
+  }
+
+  // convert to 128-based percentage to use bit shifts instead of division
+  memhigh_factor_ = (pct * 128) / 100;
+
+  REGISTER_EXIT_HOOK(interdict, [this]() { reset(); });
+
+  return 0;
+}
+
+std::string int2str(int64_t i) {
+  return i == std::numeric_limits<int64_t>::max() ? "max" : std::to_string(i);
+}
+
+void Interdict::interdict_one(
+    const CgroupContext& ctx,
+    bool activate,
+    const uint64_t tick,
+    std::ostringstream& oss) {
+  oss << "cgroup=" << ctx.cgroup().relativePath();
+
+  const auto id = ctx.id().value();
+  auto& s = saved_[id];
+  if (s.tick == 0) {
+    s.memhigh = ctx.memory_high().value_or(0);
+    s.dir = &ctx.fd();
+    oss << " saved=" << int2str(s.memhigh);
+  }
+  s.tick = tick;
+
+  const auto current = ctx.current_usage().value_or(0);
+  oss << " current=" << current;
+  int64_t limit = activate ? (current >> 7) * memhigh_factor_ : s.memhigh;
+  if (limit < 4096)
+    limit = 4096;
+
+  if (! (activate ^ s.isActive)) {
+    oss << " noop" << " isActive=" << s.isActive;
+    return;
+  }
+
+  if (const auto ret = Fs::writeMemhighAt(ctx.fd(), limit); !ret) {
+    oss << " " << ret.error().what();
+    return;
+  }
+
+  s.isActive = !s.isActive;
+
+  oss << " memory.high=" << int2str(limit) << " isActive=" << s.isActive;
+}
+
+Engine::PluginRet Interdict::run(OomdContext& ctx) {
+  const auto activate = ctx.getInvokingRuleset().has_value();
+  const auto tick = ctx.getCurrentTick();
+
+  for (const auto& cgroupCtx : ctx.addToCacheAndGet(cgroups_)) {
+    std::ostringstream oss;
+    interdict_one(cgroupCtx, activate, tick, oss);
+    OLOG << oss.str();
+  }
+
+  // purge data for removed/replaced cgroups periodically
+  if (tick % 128 == 0) {
+    for (auto it = saved_.begin(); it != saved_.end(); ) {
+      it = it->second.tick == tick ? std::next(it) : saved_.erase(it);
+    }
+  }
+
+  return Engine::PluginRet::CONTINUE;
+}
+
+void Interdict::reset() {
+  for (auto it = saved_.begin(); it != saved_.end(); it = saved_.erase(it)) {
+    auto& s = it->second;
+    Fs::writeMemhighAt(*s.dir, s.memhigh);
+  }
+}
+
+} // namespace Oomd

--- a/src/oomd/plugins/Interdict.cpp
+++ b/src/oomd/plugins/Interdict.cpp
@@ -1,8 +1,8 @@
 #include "oomd/plugins/Interdict.h"
 
+#include "oomd/ExitRegistry.h"
 #include "oomd/Log.h"
 #include "oomd/PluginRegistry.h"
-#include "oomd/ExitRegistry.h"
 
 namespace Oomd {
 
@@ -64,7 +64,7 @@ void Interdict::interdict_one(
   if (limit < 4096)
     limit = 4096;
 
-  if (! (activate ^ s.isActive)) {
+  if (!(activate ^ s.isActive)) {
     oss << " noop" << " isActive=" << s.isActive;
     return;
   }
@@ -91,7 +91,7 @@ Engine::PluginRet Interdict::run(OomdContext& ctx) {
 
   // purge data for removed/replaced cgroups periodically
   if (tick % 128 == 0) {
-    for (auto it = saved_.begin(); it != saved_.end(); ) {
+    for (auto it = saved_.begin(); it != saved_.end();) {
       it = it->second.tick == tick ? std::next(it) : saved_.erase(it);
     }
   }

--- a/src/oomd/plugins/Interdict.h
+++ b/src/oomd/plugins/Interdict.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "oomd/engine/BasePlugin.h"
+
+namespace Oomd {
+
+class Interdict : public Engine::BasePlugin {
+ public:
+  int init(
+      const Engine::PluginArgs& args,
+      const PluginConstructionContext& /* unused */) override;
+
+  Engine::PluginRet run(OomdContext& ctx) override;
+
+  static Interdict* create() {
+    return new Interdict();
+  }
+
+  ~Interdict() = default;
+
+ private:
+  // Test only
+  friend class TestHelper;
+
+  struct SavedMemhigh {
+    SavedMemhigh() : memhigh{0}, isActive{false}, tick{0}, dir{nullptr} {}
+
+    int64_t memhigh;
+    bool isActive;
+    uint64_t tick;
+    const Fs::DirFd* dir;
+  };
+  std::unordered_map<uint64_t, SavedMemhigh> saved_;
+
+  void interdict_one(
+      const Oomd::CgroupContext&,
+      bool activate,
+      uint64_t tick,
+      std::ostringstream& oss);
+
+  void reset();
+
+  std::unordered_set<CgroupPath> cgroups_;
+  int64_t memhigh_factor_{0};
+};
+
+} // namespace Oomd

--- a/src/oomd/plugins/RunCommand.cpp
+++ b/src/oomd/plugins/RunCommand.cpp
@@ -1,0 +1,111 @@
+#include "oomd/plugins/RunCommand.h"
+
+#include <signal.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <cstring>
+#include <future>
+
+#include "oomd/Log.h"
+#include "oomd/PluginRegistry.h"
+#include "oomd/util/SystemMaybe.h"
+
+namespace Oomd {
+
+REGISTER_PLUGIN(run_command, RunCommand::create);
+
+int RunCommand::init(
+    const Engine::PluginArgs& pluginArgs,
+    const PluginConstructionContext& context) {
+  std::string wholeArg;
+
+  argParser_.addArgument("command", command_, true);
+  argParser_.addArgument("use_exit_value", useExitValue_);
+  argParser_.addArgument("cache_sec", cacheSec_);
+  argParser_.addArgument("timeout_msec", timeoutMsec_);
+  argParser_.addArgument("argument", wholeArg);
+
+  if (!argParser_.parse(pluginArgs)) {
+    return 1;
+  }
+
+  args_ = Util::split(wholeArg, '\t');
+
+  c_args_.emplace_back(const_cast<char*>(command_.c_str()));
+  for (auto& s : args_)
+    c_args_.emplace_back(const_cast<char*>(s.c_str()));
+  c_args_.emplace_back(nullptr);
+
+  return 0;
+}
+
+// Fork and execute the command with a timeout
+SystemMaybe<int> RunCommand::forkexec() {
+  pid_t pid = fork();
+  if (pid == -1)
+    return systemError(errno, "Failed to fork");
+
+  if (pid == 0) {
+    // Child process
+    execvp(c_args_[0], c_args_.data());
+    _Exit(EXIT_FAILURE); // If execvp fails
+  }
+
+  // Parent process: Wait for the child process with a timeout
+  std::promise<int> result;
+  std::future<int> future = result.get_future();
+
+  std::thread waitThread([pid, &result]() {
+    int status;
+    waitpid(pid, &status, 0);
+    result.set_value(status);
+  });
+
+  if (future.wait_for(timeoutMsec_) == std::future_status::timeout) {
+    // Timeout occurred
+    kill(pid, SIGKILL); // Kill the child process
+    waitThread.join();
+    return systemError(ECANCELED, "Timeout waiting for child process");
+  }
+
+  waitThread.join();
+  int status = future.get();
+  if (status == -1)
+    return systemError(status, "Failed to wait for child process");
+
+  return status;
+}
+
+Engine::PluginRet RunCommand::run(OomdContext& ctx) {
+  using std::chrono::steady_clock;
+
+  const auto now = steady_clock::now();
+  const auto diff =
+      std::chrono::duration_cast<std::chrono::seconds>(now - start_).count();
+  if (diff < cacheSec_) {
+    const auto s = ret_ == Engine::PluginRet::CONTINUE ? "CONTINUE" : "STOP";
+    OLOG << "using cached result; diff=" << diff << " ret=" << s;
+    return ret_; // Skip execution if within cache time
+  }
+
+  start_ = now;
+
+  const auto maybe = forkexec();
+  if (!maybe) {
+    OLOG << maybe.error().what();
+    return ret_ = useExitValue_ ? Engine::PluginRet::STOP
+                                : Engine::PluginRet::CONTINUE;
+  }
+
+  ret_ = useExitValue_ && (!WIFEXITED(*maybe) || WEXITSTATUS(*maybe) != 0)
+      ? Engine::PluginRet::STOP // Non-zero exit value or killed
+      : Engine::PluginRet::CONTINUE;
+
+  const auto s = ret_ == Engine::PluginRet::CONTINUE ? "CONTINUE" : "STOP";
+  OLOG << "use_exit_value=" << useExitValue_ << " status=" << *maybe
+       << " exit=" << WEXITSTATUS(*maybe) << " ret=" << s;
+  return ret_;
+}
+
+} // namespace Oomd

--- a/src/oomd/plugins/RunCommand.h
+++ b/src/oomd/plugins/RunCommand.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <chrono>
+
+#include "oomd/engine/BasePlugin.h"
+
+namespace Oomd {
+
+class RunCommand : public Engine::BasePlugin {
+ public:
+  int init(
+      const Engine::PluginArgs& args,
+      const PluginConstructionContext& /* unused */) override;
+
+  Engine::PluginRet run(OomdContext& /* unused */) override;
+
+  static RunCommand* create() {
+    return new RunCommand();
+  }
+
+  ~RunCommand() = default;
+
+ private:
+  // Test only
+  friend class TestHelper;
+
+  SystemMaybe<int> forkexec();
+
+  std::string command_;
+  int64_t cacheSec_{0}; // Default to no caching
+  std::chrono::milliseconds timeoutMsec_{std::chrono::milliseconds(500)};
+  bool useExitValue_{false};
+  std::chrono::time_point<std::chrono::steady_clock> start_{};
+  Engine::PluginRet ret_;
+  std::vector<std::string> args_;
+  std::vector<char*> c_args_;
+};
+
+} // namespace Oomd

--- a/src/oomd/plugins/Sleep.cpp
+++ b/src/oomd/plugins/Sleep.cpp
@@ -36,11 +36,8 @@ Engine::PluginRet Sleep::run(OomdContext& ctx) {
     ret = Engine::PluginRet::CONTINUE;
   }
 
-#ifdef DEBUG
-  std::ostringstream oss;
-  oss << "duration=" << duration_ << " diff=" << diff << " ret=" << (int)ret;
-  OLOG << oss.str();
-#endif
+  const auto s = ret == Engine::PluginRet::CONTINUE ? "CONTINUE" : "STOP";
+  OLOG << "duration=" << duration_ << " diff=" << diff << " ret=" << s;
 
   return ret;
 }

--- a/src/oomd/plugins/Sleep.cpp
+++ b/src/oomd/plugins/Sleep.cpp
@@ -29,8 +29,7 @@ Engine::PluginRet Sleep::run(OomdContext& ctx) {
   auto ret = Engine::PluginRet::STOP;
   const auto now = steady_clock::now();
   const auto diff =
-      std::chrono::duration_cast<std::chrono::seconds>(now - start_)
-          .count();
+      std::chrono::duration_cast<std::chrono::seconds>(now - start_).count();
 
   if (diff >= duration_) {
     start_ = steady_clock::now();
@@ -39,8 +38,7 @@ Engine::PluginRet Sleep::run(OomdContext& ctx) {
 
 #ifdef DEBUG
   std::ostringstream oss;
-  oss << "duration=" << duration_ << " diff=" << diff
-      << " ret=" << (int) ret;
+  oss << "duration=" << duration_ << " diff=" << diff << " ret=" << (int)ret;
   OLOG << oss.str();
 #endif
 

--- a/src/oomd/plugins/Sleep.cpp
+++ b/src/oomd/plugins/Sleep.cpp
@@ -1,0 +1,50 @@
+#include "oomd/plugins/Sleep.h"
+
+#include "oomd/Log.h"
+#include "oomd/PluginRegistry.h"
+
+namespace Oomd {
+
+REGISTER_PLUGIN(sleep, Sleep::create);
+
+int Sleep::init(
+    const Engine::PluginArgs& args,
+    const PluginConstructionContext& context) {
+  using std::chrono::steady_clock;
+
+  argParser_.addArgument("duration", duration_, true);
+  if (!argParser_.parse(args)) {
+    return 1;
+  }
+
+  start_ = steady_clock::now();
+
+  // Success
+  return 0;
+}
+
+Engine::PluginRet Sleep::run(OomdContext& ctx) {
+  using std::chrono::steady_clock;
+
+  auto ret = Engine::PluginRet::STOP;
+  const auto now = steady_clock::now();
+  const auto diff =
+      std::chrono::duration_cast<std::chrono::seconds>(now - start_)
+          .count();
+
+  if (diff >= duration_) {
+    start_ = steady_clock::now();
+    ret = Engine::PluginRet::CONTINUE;
+  }
+
+#ifdef DEBUG
+  std::ostringstream oss;
+  oss << "duration=" << duration_ << " diff=" << diff
+      << " ret=" << (int) ret;
+  OLOG << oss.str();
+#endif
+
+  return ret;
+}
+
+} // namespace Oomd

--- a/src/oomd/plugins/Sleep.h
+++ b/src/oomd/plugins/Sleep.h
@@ -20,10 +20,11 @@ class Sleep : public Engine::BasePlugin {
 
   ~Sleep() = default;
 
+  // public for unit test
+  std::chrono::steady_clock::time_point start_{};
+
   private:
     int duration_;
-
-    std::chrono::steady_clock::time_point start_{};
 };
 
 } // namespace Oomd

--- a/src/oomd/plugins/Sleep.h
+++ b/src/oomd/plugins/Sleep.h
@@ -20,11 +20,12 @@ class Sleep : public Engine::BasePlugin {
 
   ~Sleep() = default;
 
-  // public for unit test
-  std::chrono::steady_clock::time_point start_{};
+ private:
+  // Test only
+  friend class TestHelper;
 
-  private:
     int duration_;
+    std::chrono::steady_clock::time_point start_{};
 };
 
 } // namespace Oomd

--- a/src/oomd/plugins/Sleep.h
+++ b/src/oomd/plugins/Sleep.h
@@ -24,8 +24,8 @@ class Sleep : public Engine::BasePlugin {
   // Test only
   friend class TestHelper;
 
-    int duration_;
-    std::chrono::steady_clock::time_point start_{};
+  int duration_;
+  std::chrono::steady_clock::time_point start_{};
 };
 
 } // namespace Oomd

--- a/src/oomd/plugins/Sleep.h
+++ b/src/oomd/plugins/Sleep.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <chrono>
+
+#include "oomd/engine/BasePlugin.h"
+
+namespace Oomd {
+
+class Sleep : public Engine::BasePlugin {
+ public:
+  int init(
+      const Engine::PluginArgs& args,
+      const PluginConstructionContext& context) override;
+
+  Engine::PluginRet run(OomdContext& /* unused */) override;
+
+  static Sleep* create() {
+    return new Sleep();
+  }
+
+  ~Sleep() = default;
+
+  private:
+    int duration_;
+
+    std::chrono::steady_clock::time_point start_{};
+};
+
+} // namespace Oomd

--- a/src/oomd/util/Fs.cpp
+++ b/src/oomd/util/Fs.cpp
@@ -764,6 +764,14 @@ SystemMaybe<Unit> Fs::writeMemhightmpAt(
   return noSystemError();
 }
 
+SystemMaybe<int64_t> Fs::readMemReclaimAt(const DirFd& dirfd) {
+  auto lines = readFileByLine(Fs::Fd::openat(dirfd, kMemReclaimFile));
+  if (!lines) {
+    return SYSTEM_ERROR(lines.error());
+  }
+  return static_cast<int64_t>(std::stoll((*lines)[0]));
+}
+
 SystemMaybe<Unit> Fs::writeMemReclaimAt(
     const DirFd& dirfd,
     int64_t value,

--- a/src/oomd/util/Fs.h
+++ b/src/oomd/util/Fs.h
@@ -235,6 +235,7 @@ class Fs {
       const DirFd& dirfd,
       int64_t value,
       std::chrono::microseconds duration);
+  static SystemMaybe<int64_t> readMemReclaimAt(const DirFd& dirfd);
   static SystemMaybe<Unit> writeMemReclaimAt(
       const DirFd& dirfd,
       int64_t value,

--- a/src/oomd/util/PluginArgParser.cpp
+++ b/src/oomd/util/PluginArgParser.cpp
@@ -149,6 +149,12 @@ std::chrono::milliseconds PluginArgParser::parseValue(
 }
 
 template <>
+std::chrono::seconds PluginArgParser::parseValue(
+    const std::string& valueString) {
+  return std::chrono::seconds(std::stoll(valueString));
+}
+
+template <>
 ResourceType PluginArgParser::parseValue(const std::string& valueString) {
   if (valueString == "io") {
     return ResourceType::IO;

--- a/src/oomd/util/TestHelper.h
+++ b/src/oomd/util/TestHelper.h
@@ -86,7 +86,7 @@ class TestHelper {
   }
 
   static void dropCgroup(OomdContext& ctx, const CgroupPath& cgroup) {
-    for (auto it = ctx.cgroups_.begin(); it != ctx.cgroups_.end(); )
+    for (auto it = ctx.cgroups_.begin(); it != ctx.cgroups_.end();)
       it = it->first != cgroup ? std::next(it) : ctx.cgroups_.erase(it);
   }
 

--- a/src/oomd/util/TestHelper.h
+++ b/src/oomd/util/TestHelper.h
@@ -21,6 +21,8 @@
 #include "oomd/OomdContext.h"
 #include "oomd/PluginRegistry.h"
 #include "oomd/engine/PrekillHook.h"
+#include "oomd/plugins/Interdict.h"
+#include "oomd/plugins/Sleep.h"
 
 #define ASSERT_EXISTS(opt_expr) \
   ({                            \
@@ -56,6 +58,10 @@ class TestHelper {
     return ctx.cgroups_;
   }
 
+  static void setCurrentTick(OomdContext& ctx, uint64_t x) {
+    ctx.current_tick_ = x;
+  }
+
   /*
    * Set the cgroup data of a CgroupContext in OomdContext.
    * This is a shortcut for setting up CgroupContext without creating control
@@ -77,6 +83,23 @@ class TestHelper {
         cached_ctx.archive_ = *archive;
       }
     }
+  }
+
+  static void dropCgroup(OomdContext& ctx, const CgroupPath& cgroup) {
+    for (auto it = ctx.cgroups_.begin(); it != ctx.cgroups_.end(); )
+      it = it->first != cgroup ? std::next(it) : ctx.cgroups_.erase(it);
+  }
+
+  static std::chrono::steady_clock::time_point getSleepStart(Sleep* s) {
+    return s->start_;
+  }
+
+  static void setSleepStart(Sleep* s, std::chrono::steady_clock::time_point x) {
+    s->start_ = x;
+  }
+
+  static size_t getSavedSize(Interdict* i) {
+    return i->saved_.size();
   }
 };
 

--- a/src/oomd/util/TestHelper.h
+++ b/src/oomd/util/TestHelper.h
@@ -22,6 +22,7 @@
 #include "oomd/PluginRegistry.h"
 #include "oomd/engine/PrekillHook.h"
 #include "oomd/plugins/Interdict.h"
+#include "oomd/plugins/RunCommand.h"
 #include "oomd/plugins/Sleep.h"
 
 #define ASSERT_EXISTS(opt_expr) \
@@ -100,6 +101,10 @@ class TestHelper {
 
   static size_t getSavedSize(Interdict* i) {
     return i->saved_.size();
+  }
+
+  static size_t getArgsSize(RunCommand* r) {
+    return r->c_args_.size();
   }
 };
 

--- a/src/oomd/util/Util.cpp
+++ b/src/oomd/util/Util.cpp
@@ -169,7 +169,7 @@ std::vector<std::string> Util::split(const std::string& line, char delim) {
   std::vector<std::string> ret;
 
   auto emplaceNonEmptySubstr = [&ret, &line](size_t beg, size_t end) {
-    if (size_t len = end - beg) {
+    if (end - beg) {
       ret.emplace_back(line.begin() + beg, line.begin() + end);
     }
   };


### PR DESCRIPTION
See fork_changes.md in this PR for docs.  From the doc:
This branch adds new plugins and makes small changes to the oomd engine to complement them. The new plugins are: sleep, always_reclaim, interdict, and run_command. The engine now supports an exit registry where plugins can add functions to run at oomd exit, and an always-continue flag to always run a ruleset's actions which may behave differently when detectors fail to match.