### PR TITLE
always_reclaim, kill-index, and more

### DIFF
--- a/docs/fork_changes.md
+++ b/docs/fork_changes.md
@@ -1,0 +1,83 @@
+# Changes to the fork branch
+
+This branch adds new plugins and makes small changes to the oomd engine
+to complement them.  The new plugins are: sleep, always_reclaim, interdict,
+and run_command.  The engine now supports an exit registry where plugins
+can add functions to run at oomd exit, and an always-continue flag to
+always run a ruleset's actions which may behave differently when detectors
+fail to match.
+
+# Plugins
+
+## sleep
+
+### Arguments
+
+    duration (in seconds)
+
+### Description
+
+This plugin allows an action to occur periodically at an interval greater
+than the duration of the event loop, especially for use with `always_reclaim`.
+
+CONTINUE if more than `duration` seconds have elapsed since the last
+CONTINUE, otherwise STOP.
+
+## always_reclaim
+
+### Arguments
+
+    cgroup
+    reclaim_bytes
+
+This plugin launches a reclamation of `reclaim_bytes` for the cgroup(s)
+specified in `cgroup`.  Reclamation consists of a write to the
+`memory.reclaim` file of the cgroup.  The plugin always returns CONTINUE.
+
+### Description
+
+## interdict
+
+### Arguments
+
+    cgroup
+    memhigh_pct (from 1 to 99)
+
+### Description
+
+This plugin toggles a cgroup's `memory.high` limit between its current
+value and a reduced value.  The intent is, under sufficient memory
+contention, to encumber low-priority cgroups enough that the kernel
+throttles further memory allocations.  Once the contention subsides,
+the cgroup is unencumbered.  NB. the ruleset must specify
+`"always-continue": true` for the plugin to operate correctly.
+
+When all detectors return CONTINUE, this plugin writes a value to
+the cgroup `memory.high` file that is `memhigh_pct` percentage of the
+value in `memory.current` and saves the prior value from `memory.high`.
+If a detector returns STOP, the plugin writes the saved value back to
+`memory.high`.  The plugin always returns CONTINUE.  At oomd exit,
+all saved values are written back.
+
+## run_command
+
+### Arguments
+
+    command
+    argument
+    use_exit_value
+    cache_sec
+    timeout_msec
+
+### Description
+
+This plugin runs `command` with optional `argument` in which multiple
+arguments may be specified by separating them with a tab (`\t`).
+If `use_exit_value` is true, then the plugin returns CONTINUE for a
+0 exit value and STOP otherwise.  If `use_exit_value` is false, the
+default, then the plugin returns CONTINUE.
+
+If `cache_sec`, default 0, is greater than 0 then the plugin returns
+the value from the last run for the duration specified.  If `timeout_msec`,
+default 500 milliseconds, is greater than 0, then a run exceeding the
+timeout is killed.  With `use_exit_value` true, a killed run returns STOP.

--- a/docs/fork_changes.md
+++ b/docs/fork_changes.md
@@ -3,9 +3,54 @@
 This branch adds new plugins and makes small changes to the oomd engine
 to complement them.  The new plugins are: sleep, always_reclaim, interdict,
 and run_command.  The engine now supports an exit registry where plugins
-can add functions to run at oomd exit, and an always-continue flag to
+can add functions to run at oomd exit, an always-continue flag to
 always run a ruleset's actions which may behave differently when detectors
-fail to match.
+fail to match, and a per-ruleset kill-index section to modify kill targets.
+
+
+# Ruleset
+
+## kill-index
+
+A ruleset may contain a `kill-index` section that pairs a cgroup relative
+path with an integer.  When sorting target cgroups to select a kill candidate,
+this integer acts as the primary sort key.  `oomd` chooses the cgroup with the
+greatest index.  cgroups default to an index value of 0.  `oomd` never chooses
+a cgroup with a negative index.  Without a `kill-index` section, `oomd`
+defaults to its original sort using extended attributes, "trusted.oomd_prefer"
+and "trusted.oomd_avoid".
+
+### Example
+
+    {
+      "rulesets": [
+        {
+          "name": "test kills",
+          "kill-index": {
+            "system.slice/test1.service": -1,
+            "system.slice/test2.service": 4,
+            "system.slice/test2.service": 9
+          },
+          "detectors": [
+            [
+              "cgroups named test",
+              {
+                "name": "exists",
+                "args": { "cgroup": "system.slice/test*service" }
+              }
+            ]
+          ],
+          "actions": [
+            {
+              "name": "kill_by_pressure",
+              "args": { "cgroup": "system.slice/test*service",
+                        "resource": "memory", "dry": "true" }
+            }
+          ]
+        }
+      ]
+    }
+
 
 # Plugins
 

--- a/docs/fork_changes.md
+++ b/docs/fork_changes.md
@@ -28,6 +28,7 @@ CONTINUE, otherwise STOP.
 ### Arguments
 
     cgroup
+    ruleset_cgroup (optional)
     reclaim_bytes
 
 This plugin launches a reclamation of `reclaim_bytes` for the cgroup(s)
@@ -41,6 +42,7 @@ specified in `cgroup`.  Reclamation consists of a write to the
 ### Arguments
 
     cgroup
+    ruleset_cgroup (optional)
     memhigh_pct (from 1 to 99)
 
 ### Description

--- a/meson.build
+++ b/meson.build
@@ -62,6 +62,7 @@ srcs = files('''
     src/oomd/plugins/Sleep.cpp
     src/oomd/plugins/AlwaysReclaim.cpp
     src/oomd/plugins/Interdict.cpp
+    src/oomd/plugins/RunCommand.cpp
     src/oomd/util/Fs.cpp
     src/oomd/util/Util.cpp
     src/oomd/util/PluginArgParser.cpp

--- a/meson.build
+++ b/meson.build
@@ -29,6 +29,7 @@ srcs = files('''
     src/oomd/Stats.cpp
     src/oomd/StatsClient.cpp
     src/oomd/PluginRegistry.cpp
+    src/oomd/ExitRegistry.cpp
     src/oomd/config/ConfigCompiler.cpp
     src/oomd/config/ConfigTypes.cpp
     src/oomd/config/JsonConfigParser.cpp
@@ -60,6 +61,7 @@ srcs = files('''
     src/oomd/plugins/KillPressure.cpp
     src/oomd/plugins/Sleep.cpp
     src/oomd/plugins/AlwaysReclaim.cpp
+    src/oomd/plugins/Interdict.cpp
     src/oomd/util/Fs.cpp
     src/oomd/util/Util.cpp
     src/oomd/util/PluginArgParser.cpp

--- a/meson.build
+++ b/meson.build
@@ -58,6 +58,8 @@ srcs = files('''
     src/oomd/plugins/KillSwapUsage.cpp
     src/oomd/plugins/KillPgScan.cpp
     src/oomd/plugins/KillPressure.cpp
+    src/oomd/plugins/Sleep.cpp
+    src/oomd/plugins/AlwaysReclaim.cpp
     src/oomd/util/Fs.cpp
     src/oomd/util/Util.cpp
     src/oomd/util/PluginArgParser.cpp

--- a/src/oomd/ExitRegistry.cpp
+++ b/src/oomd/ExitRegistry.cpp
@@ -1,0 +1,10 @@
+#include "ExitRegistry.h"
+
+namespace Oomd {
+
+ExitRegistry& getExitRegistry() {
+  static ExitRegistry r;
+  return r;
+}
+
+} // namespace Oomd

--- a/src/oomd/ExitRegistry.h
+++ b/src/oomd/ExitRegistry.h
@@ -1,0 +1,35 @@
+#include <functional>
+#include <string>
+#include <unordered_map>
+
+namespace Oomd {
+
+class ExitRegistry {
+ public:
+  using ExitFunction = std::function<void()>;
+  using ExitMap = std::unordered_map<std::string, ExitFunction>;
+
+  bool add(const std::string& name, ExitFunction f) {
+    if (map_.find(name) != map_.end()) {
+      return false;
+    }
+
+    map_[name] = f;
+    return true;
+  }
+
+  void callHooks() {
+    for (auto const& data : map_)
+      data.second();
+  }
+
+ private:
+  ExitMap map_;
+};
+
+ExitRegistry& getExitRegistry();
+
+#define REGISTER_EXIT_HOOK(hook_name, exit_func) \
+  getExitRegistry().add(#hook_name, (exit_func))
+
+} // namespace Oomd

--- a/src/oomd/Log.cpp
+++ b/src/oomd/Log.cpp
@@ -72,7 +72,7 @@ Log::~Log() {
 }
 
 bool Log::init(const std::string& kmsg_path) {
-  int kmsg_fd = ::open(kmsg_path.c_str(), O_WRONLY | O_CREAT | O_APPEND, 0644);
+  int kmsg_fd = ::open(kmsg_path.c_str(), O_WRONLY | O_CREAT | O_APPEND | O_CLOEXEC, 0644);
   if (kmsg_fd < 0) {
     perror("open");
     std::cerr << "Unable to open outfile " << kmsg_path << ", not logging\n";

--- a/src/oomd/Main.cpp
+++ b/src/oomd/Main.cpp
@@ -86,6 +86,7 @@ static void printUsage() {
          "  --version, -v              Print version and exit\n"
          "  --config, -C CONFIG        Config file (default: /etc/oomd.json)\n"
          "  --interval, -i INTERVAL    Event loop polling interval (default: 5)\n"
+         "  --config-interval, -I n    Check for config changes every n seconds (default: 60s; 0 to disable)\n"
          "  --cgroup-fs, -f FS         Cgroup2 filesystem mount point (default: /sys/fs/cgroup)\n"
          "  --check-config, -c CONFIG  Check config file (default: /etc/oomd.json)\n"
          "  --list-plugins, -l         List all available plugins\n"
@@ -137,7 +138,7 @@ static std::unique_ptr<Oomd::Config2::IR::Root> parseConfig(
   std::stringstream buf;
   buf << conf_file.rdbuf();
   Oomd::Config2::JsonConfigParser json_parser;
-  auto ir = json_parser.parse(buf.str());
+  auto ir = json_parser.parse(buf.str(), flag_conf_file);
   if (!ir) {
     std::cerr << "Could not parse conf_file=" << flag_conf_file << std::endl;
     return nullptr;
@@ -204,7 +205,7 @@ static bool initRuntimeDir(const fs::path& runtime_dir) {
   fs::path lockfile = runtime_dir / kRuntimeLock;
 
   // Don't bother storing file lock FD. Just let it close when process exits.
-  int lockfd = ::open(lockfile.c_str(), O_CREAT, S_IRUSR | S_IWUSR);
+  int lockfd = ::open(lockfile.c_str(), O_CREAT | O_CLOEXEC, S_IRUSR | S_IWUSR);
   if (lockfd < 0) {
     OLOG << "Failed to open lock file=" << lockfile << ": "
          << ::strerror_r(errno, err_buf.data(), err_buf.size());
@@ -235,6 +236,7 @@ int main(int argc, char** argv) {
   std::string dev_id;
   std::string kmsg_path = kKmsgPath;
   int interval = 5;
+  int config_interval = 60;
   bool should_check_config = false;
 
   int option_index = 0;
@@ -254,7 +256,7 @@ int main(int argc, char** argv) {
     exit(EXIT_FAILURE);
   }
 
-  const char* const short_options = "hvC:w:i:f:c:lD:dr";
+  const char* const short_options = "hvC:w:i:f:c:lD:drk:I:";
   option long_options[] = {
       option{"help", no_argument, nullptr, 'h'},
       option{"version", no_argument, nullptr, 'v'},
@@ -271,6 +273,7 @@ int main(int argc, char** argv) {
       option{"ssd-coeffs", required_argument, nullptr, OPT_SSD_COEFFS},
       option{"hdd-coeffs", required_argument, nullptr, OPT_HDD_COEFFS},
       option{"kmsg-override", required_argument, nullptr, 'k'},
+      option{"config-interval", required_argument, nullptr, 'I'},
       option{nullptr, 0, nullptr, 0}};
 
   while ((c = getopt_long(
@@ -312,7 +315,17 @@ int main(int argc, char** argv) {
           std::cerr << "Interval not a >0 integer: " << optarg << std::endl;
           return 1;
         }
-
+        break;
+      case 'I':
+        try {
+          config_interval = std::stoi(optarg, &parsed_len);
+        } catch (const std::invalid_argument&) {
+          parse_error = true;
+        }
+        if (parse_error || config_interval < 0 || parsed_len != strlen(optarg)) {
+          std::cerr << "Interval is negative: " << optarg << std::endl;
+          return 1;
+        }
         break;
       case 'f':
         cgroup_fs = std::string(optarg);
@@ -486,10 +499,12 @@ int main(int argc, char** argv) {
       std::move(ir),
       std::move(engine),
       interval,
+      config_interval,
       cgroup_fs,
       drop_in_dir,
       *io_devs,
       hdd_coeffs,
       ssd_coeffs);
-  return oomd.run(&mask);
+  auto ret = oomd.run(&mask);
+  return ret == -2 ? execv(argv[0], argv) : ret;
 }

--- a/src/oomd/Main.cpp
+++ b/src/oomd/Main.cpp
@@ -27,6 +27,7 @@
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <unistd.h>
 #include <unordered_map>
 
 #include <getopt.h>

--- a/src/oomd/Oomd.cpp
+++ b/src/oomd/Oomd.cpp
@@ -23,13 +23,13 @@
 #include <thread>
 
 #include "oomd/CgroupContext.h"
+#include "oomd/ExitRegistry.h"
 #include "oomd/Log.h"
 #include "oomd/dropin/FsDropInService.h"
 #include "oomd/include/Assert.h"
 #include "oomd/include/Defines.h"
 #include "oomd/util/Fs.h"
 #include "oomd/util/Util.h"
-#include "oomd/ExitRegistry.h"
 namespace Oomd {
 
 Oomd::Oomd(

--- a/src/oomd/Oomd.cpp
+++ b/src/oomd/Oomd.cpp
@@ -29,6 +29,7 @@
 #include "oomd/include/Defines.h"
 #include "oomd/util/Fs.h"
 #include "oomd/util/Util.h"
+#include "oomd/ExitRegistry.h"
 namespace Oomd {
 
 Oomd::Oomd(
@@ -137,6 +138,7 @@ int Oomd::run(const sigset_t* mask) {
     } else if (rc != -1) {
       // Synchronously log to stderr so there's no buffering
       std::cerr << "Received signal " << rc << ". Exiting!";
+      getExitRegistry().callHooks();
       pthread_sigmask(SIG_UNBLOCK, mask, nullptr);
       pthread_kill(pthread_self(), rc);
       return -1;

--- a/src/oomd/Oomd.cpp
+++ b/src/oomd/Oomd.cpp
@@ -20,6 +20,7 @@
 #include <signal.h>
 #include <cmath>
 #include <functional>
+#include <sys/stat.h>
 #include <thread>
 
 #include "oomd/CgroupContext.h"
@@ -36,12 +37,14 @@ Oomd::Oomd(
     std::unique_ptr<Config2::IR::Root> ir_root,
     std::unique_ptr<Engine::Engine> engine,
     int interval,
+    int config_interval,
     const std::string& cgroup_fs,
     const std::string& drop_in_dir,
     const std::unordered_map<std::string, DeviceType>& io_devs,
     const IOCostCoeffs& hdd_coeffs,
     const IOCostCoeffs& ssd_coeffs)
     : interval_(interval),
+      config_interval_(config_interval),
       ir_root_(std::move(ir_root)),
       engine_(std::move(engine)) {
   ContextParams params{
@@ -112,6 +115,15 @@ void Oomd::updateContext() {
 }
 
 int Oomd::run(const sigset_t* mask) {
+  struct stat first_sb;
+  auto last_stat = time(NULL);
+  auto config_interval = config_interval_.count();
+  if (config_interval > 0 && ::stat(ir_root_->path.c_str(), &first_sb) == -1) {
+    OLOG << "Failed to stat config file: " << ir_root_->path << "; "
+         << Util::strerror_r() << "\n";
+    return EXIT_CANT_RECOVER;
+  }
+
   if (!engine_) {
     OLOG << "Could not run engine. Your config file is probably invalid\n";
     return EXIT_CANT_RECOVER;
@@ -155,6 +167,20 @@ int Oomd::run(const sigset_t* mask) {
 
     // Run all the plugins
     engine_->runOnce(ctx_);
+
+    if (config_interval > 0) {
+      auto now = time(NULL);
+      if (now-last_stat >= config_interval) {
+        last_stat = now;
+        struct stat sb;
+        if (::stat(ir_root_->path.c_str(), &sb) != -1 &&
+            (first_sb.st_ino != sb.st_ino ||
+             first_sb.st_mtim.tv_sec != sb.st_mtim.tv_sec)) {
+          OLOG << "Config file changed - restart";
+          return -2;
+        }
+      }
+    }
   }
 
   return 0;

--- a/src/oomd/Oomd.h
+++ b/src/oomd/Oomd.h
@@ -41,6 +41,7 @@ class Oomd {
       std::unique_ptr<Config2::IR::Root> ir_root,
       std::unique_ptr<Engine::Engine> engine,
       int interval,
+      int config_interval,
       const std::string& cgroup_fs,
       const std::string& drop_in_dir,
       const std::unordered_map<std::string, DeviceType>& io_devs = {},
@@ -54,6 +55,7 @@ class Oomd {
  private:
   // runtime settings
   std::chrono::seconds interval_{0};
+  std::chrono::seconds config_interval_{0};
   std::unique_ptr<Config2::IR::Root> ir_root_;
   std::unique_ptr<Engine::Engine> engine_;
   std::unique_ptr<DropInServiceAdaptor> fs_drop_in_service_;

--- a/src/oomd/OomdContext.cpp
+++ b/src/oomd/OomdContext.cpp
@@ -146,6 +146,10 @@ void OomdContext::setInvokingRuleset(std::optional<Engine::Ruleset*> ruleset) {
   invoking_ruleset_ = ruleset;
 }
 
+void OomdContext::setInvokingKillIndex(std::optional<std::unordered_map<std::string, int>*> p) {
+  invoking_kill_index_ = p;
+}
+
 const std::optional<CgroupPath> OomdContext::getRulesetCgroup() const {
   return ruleset_cgroup_;
 }

--- a/src/oomd/OomdContext.h
+++ b/src/oomd/OomdContext.h
@@ -122,11 +122,41 @@ class OomdContext {
   }
 
   /*
+   * Sorts cgroups by kill_index, then get_key. Highest first to lowest
+   * last. Removes cgroups that must not be killed.
+   * Returns new vec; does not mutate cgroups arg.
+   */
+  template <class Functor>
+  static std::vector<ConstCgroupContextRef> sortDescWithKillIndex(
+      OomdContext& ctx,
+      const std::vector<ConstCgroupContextRef>& cgroups,
+      Functor&& get_key) {
+
+    auto kill_index = [&](ConstCgroupContextRef r) {
+      auto index = *ctx.invoking_kill_index_;
+      auto it = index->find(r.get().cgroup().relativePath());
+      return it != index->end() ? it->second : int(KillPreference::NORMAL);
+    };
+
+    std::vector<ConstCgroupContextRef> ret;
+    std::copy_if(cgroups.begin(), cgroups.end(), std::back_inserter(ret),
+        [&](const auto& r){ return kill_index(r) >= int(KillPreference::NORMAL); });
+
+    std::sort(ret.begin(), ret.end(), [&](const auto& a, const auto& b) {
+      return std::make_tuple(kill_index(a), get_key(a.get())) >
+             std::make_tuple(kill_index(b), get_key(b.get()));
+    });
+
+    return ret;
+  }
+
+  /*
    * Sorts cgroups by kill_preference, then get_key. Highest first to lowest
    * last. Returns new vec; does not mutate cgroups arg.
    */
   template <class Functor>
   static std::vector<ConstCgroupContextRef> sortDescWithKillPrefs(
+      OomdContext& ctx,
       const std::vector<ConstCgroupContextRef>& cgroups,
       Functor&& get_key) {
     auto sorted = cgroups;
@@ -139,6 +169,21 @@ class OomdContext {
                  get_key(b.get()));
     });
     return sorted;
+  }
+
+  /*
+   * Use kill index values supplied in rulset if available, otherwise
+   * use attribute-based kill preference.
+   */
+  template <class Functor>
+  static std::vector<ConstCgroupContextRef> sortDescWithKillValue(
+      OomdContext& ctx,
+      const std::vector<ConstCgroupContextRef>& cgroups,
+      Functor&& get_key) {
+    if (ctx.invoking_kill_index_)
+      return sortDescWithKillIndex(ctx, cgroups, get_key);
+    else
+      return sortDescWithKillPrefs(ctx, cgroups, get_key);
   }
 
   /*
@@ -174,6 +219,7 @@ class OomdContext {
    */
   const std::optional<Engine::Ruleset*> getInvokingRuleset();
   void setInvokingRuleset(std::optional<Engine::Ruleset*> ruleset);
+  void setInvokingKillIndex(std::optional<std::unordered_map<std::string, int>*> p);
 
   /*
    * Used to let kill plugins invoke prekill hooks
@@ -206,6 +252,7 @@ class OomdContext {
   SystemContext system_ctx_;
   uint64_t current_tick_{0};
   std::optional<Engine::Ruleset*> invoking_ruleset_{std::nullopt};
+  std::optional<std::unordered_map<std::string, int>*> invoking_kill_index_{std::nullopt};
   std::function<std::optional<std::unique_ptr<Engine::PrekillHookInvocation>>(
       const CgroupContext& cgroup_ctx)>
       prekill_hook_handler_{nullptr};

--- a/src/oomd/OomdContext.h
+++ b/src/oomd/OomdContext.h
@@ -180,10 +180,11 @@ class OomdContext {
       OomdContext& ctx,
       const std::vector<ConstCgroupContextRef>& cgroups,
       Functor&& get_key) {
-    if (ctx.invoking_kill_index_)
-      return sortDescWithKillIndex(ctx, cgroups, get_key);
-    else
+    auto optindex = ctx.invoking_kill_index_;
+    if (!optindex || (*optindex)->empty())
       return sortDescWithKillPrefs(ctx, cgroups, get_key);
+    else
+      return sortDescWithKillIndex(ctx, cgroups, get_key);
   }
 
   /*

--- a/src/oomd/Stats.cpp
+++ b/src/oomd/Stats.cpp
@@ -102,7 +102,7 @@ bool& Stats::isInitInternal() {
 bool Stats::startSocket() {
   std::array<char, 64> err_buf = {};
 
-  sockfd_ = ::socket(AF_UNIX, SOCK_STREAM, 0);
+  sockfd_ = ::socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
   if (sockfd_ < 0) {
     OLOG << "Error creating socket: "
          << ::strerror_r(errno, err_buf.data(), err_buf.size() - 1);

--- a/src/oomd/config/ConfigCompiler.cpp
+++ b/src/oomd/config/ConfigCompiler.cpp
@@ -186,6 +186,7 @@ std::unique_ptr<Oomd::Engine::Ruleset> compileRuleset(
       ruleset.dropin.disable_on_drop_in,
       ruleset.dropin.detectorgroups_enabled,
       ruleset.dropin.actiongroup_enabled,
+      ruleset.always_continue,
       silenced_logs,
       post_action_delay,
       prekill_hook_timeout,

--- a/src/oomd/config/ConfigCompiler.cpp
+++ b/src/oomd/config/ConfigCompiler.cpp
@@ -192,7 +192,8 @@ std::unique_ptr<Oomd::Engine::Ruleset> compileRuleset(
       prekill_hook_timeout,
       ruleset.xattr_filter,
       context.cgroupFs(),
-      ruleset.cgroup);
+      ruleset.cgroup,
+      std::move(ruleset.kill_index));
 }
 
 } // namespace

--- a/src/oomd/config/ConfigCompilerTest.cpp
+++ b/src/oomd/config/ConfigCompilerTest.cpp
@@ -397,6 +397,34 @@ TEST_F(CompilerTest, MultiGroupIncrementCount) {
   EXPECT_EQ(count, 6);
 }
 
+// redo the last test but with always_continue=true
+TEST_F(CompilerTest, AlwaysContinueIncrementCount) {
+  IR::Detector cont;
+  cont.name = "Continue";
+  IR::Detector stop;
+  stop.name = "Stop";
+  IR::Action increment;
+  increment.name = "IncrementCount";
+  IR::DetectorGroup dgroup1{"group1", {cont}};
+  IR::DetectorGroup dgroup2{"group2", {stop}};
+  IR::DetectorGroup dgroup3{"group3", {cont}};
+  IR::Ruleset ruleset1{"ruleset1", {dgroup1}, {increment}, {}, "", "", ""};
+  IR::Ruleset ruleset2{"ruleset2", {dgroup2}, {increment}, {}, "", "", ""};
+  ruleset2.always_continue = true;
+  IR::Ruleset ruleset3{"ruleset3", {dgroup3}, {increment}, {}, "", "", ""};
+  root.rulesets.emplace_back(std::move(ruleset1));
+  root.rulesets.emplace_back(std::move(ruleset2));
+  root.rulesets.emplace_back(std::move(ruleset3));
+
+  auto engine = compile();
+  ASSERT_TRUE(engine);
+  for (int i = 0; i < 3; ++i) {
+    engine->runOnce(context);
+  }
+
+  EXPECT_EQ(count, 9);
+}
+
 TEST_F(CompilerTest, AsyncAction) {
   IR::Action cont{IR::Plugin{.name = "Continue"}};
   IR::Action inc{IR::Plugin{.name = "IncrementCount"}};

--- a/src/oomd/config/ConfigTypes.cpp
+++ b/src/oomd/config/ConfigTypes.cpp
@@ -83,6 +83,8 @@ void dumpIR(const Root& root) {
          << "PrekillHookTimeout=" << ruleset.prekill_hook_timeout;
     OLOG << getIndentSpaces(indent) << "XattrFilter=" << ruleset.xattr_filter;
     OLOG << getIndentSpaces(indent) << "Cgroup=" << ruleset.cgroup;
+    OLOG << getIndentSpaces(indent)
+         << "AlwaysContinue=" << ruleset.always_continue;
 
     // Print DetectorGroup's
     for (const auto& dg : ruleset.dgs) {

--- a/src/oomd/config/ConfigTypes.cpp
+++ b/src/oomd/config/ConfigTypes.cpp
@@ -86,6 +86,13 @@ void dumpIR(const Root& root) {
     OLOG << getIndentSpaces(indent)
          << "AlwaysContinue=" << ruleset.always_continue;
 
+    OLOG << getIndentSpaces(indent) << "KillIndex=";
+    ++indent;
+    for (const auto& pair : ruleset.kill_index) {
+          OLOG << getIndentSpaces(indent) << pair.first << "=" << pair.second;
+    }
+    --indent;
+
     // Print DetectorGroup's
     for (const auto& dg : ruleset.dgs) {
       OLOG << getIndentSpaces(indent) << "DetectorGroup=" << dg.name;

--- a/src/oomd/config/ConfigTypes.h
+++ b/src/oomd/config/ConfigTypes.h
@@ -69,12 +69,12 @@ struct Ruleset {
   std::vector<DetectorGroup> dgs;
   std::vector<Action> acts;
   DropIn dropin;
-  bool always_continue{false};
   std::string silence_logs;
   std::string post_action_delay;
   std::string prekill_hook_timeout;
   std::string xattr_filter;
   std::string cgroup;
+  bool always_continue{false};
 };
 
 struct Root {

--- a/src/oomd/config/ConfigTypes.h
+++ b/src/oomd/config/ConfigTypes.h
@@ -69,6 +69,7 @@ struct Ruleset {
   std::vector<DetectorGroup> dgs;
   std::vector<Action> acts;
   DropIn dropin;
+  bool always_continue{false};
   std::string silence_logs;
   std::string post_action_delay;
   std::string prekill_hook_timeout;

--- a/src/oomd/config/ConfigTypes.h
+++ b/src/oomd/config/ConfigTypes.h
@@ -75,6 +75,7 @@ struct Ruleset {
   std::string xattr_filter;
   std::string cgroup;
   bool always_continue{false};
+  std::unordered_map<std::string, int> kill_index;
 };
 
 struct Root {

--- a/src/oomd/config/ConfigTypes.h
+++ b/src/oomd/config/ConfigTypes.h
@@ -81,6 +81,7 @@ struct Ruleset {
 struct Root {
   std::vector<Ruleset> rulesets;
   std::vector<PrekillHook> prekill_hooks;
+  std::string path;
 };
 
 void dumpIR(const Root& root);

--- a/src/oomd/config/JsonConfigParser.cpp
+++ b/src/oomd/config/JsonConfigParser.cpp
@@ -111,6 +111,8 @@ Oomd::Config2::IR::Ruleset parseRuleset(const Json::Value& ruleset) {
 
   ir_ruleset.dropin = parseDropIn(ruleset.get("drop-in", {}));
 
+  ir_ruleset.always_continue = ruleset.get("always-continue", false).asBool();
+
   ir_ruleset.silence_logs = ruleset.get("silence-logs", {}).asString();
 
   ir_ruleset.post_action_delay =

--- a/src/oomd/config/JsonConfigParser.cpp
+++ b/src/oomd/config/JsonConfigParser.cpp
@@ -104,6 +104,25 @@ Oomd::Config2::IR::DropIn parseDropIn(const Json::Value& dropin) {
   return ir_dropin;
 }
 
+std::unordered_map<std::string, int> parseKillIndex(const Json::Value& dict) {
+  if (!dict.isObject()) {
+    return {};
+  }
+
+  std::unordered_map<std::string, int> ret;
+
+  for (const auto& key : dict.getMemberNames()) {
+    const auto& value = dict[key];
+    if (!value.isNumeric()) {
+      OLOG << "Value is not a number in kill-index" << value.asString();
+      throw std::runtime_error("Invalid config");
+    }
+    ret[key] = value.asInt();
+  }
+
+  return ret;
+}
+
 Oomd::Config2::IR::Ruleset parseRuleset(const Json::Value& ruleset) {
   Oomd::Config2::IR::Ruleset ir_ruleset;
 
@@ -132,6 +151,8 @@ Oomd::Config2::IR::Ruleset parseRuleset(const Json::Value& ruleset) {
 
   ir_ruleset.xattr_filter = ruleset.get("xattr_filter", {}).asString();
   ir_ruleset.cgroup = ruleset.get("cgroup", {}).asString();
+
+  ir_ruleset.kill_index = parseKillIndex(ruleset.get("kill-index", {}));
 
   return ir_ruleset;
 }

--- a/src/oomd/config/JsonConfigParser.cpp
+++ b/src/oomd/config/JsonConfigParser.cpp
@@ -162,10 +162,12 @@ Oomd::Config2::IR::Ruleset parseRuleset(const Json::Value& ruleset) {
 namespace Oomd {
 namespace Config2 {
 
-std::unique_ptr<IR::Root> JsonConfigParser::parse(const std::string& input) {
+std::unique_ptr<IR::Root> JsonConfigParser::parse(const std::string& input, const std::string& path) {
   Json::Value json_root;
   getJson(json_root, input);
   auto ir_root = std::make_unique<IR::Root>();
+
+  ir_root->path = std::move(path);
 
   for (const auto& ruleset : json_root.get("rulesets", {})) {
     ir_root->rulesets.emplace_back(parseRuleset(ruleset));

--- a/src/oomd/config/JsonConfigParser.h
+++ b/src/oomd/config/JsonConfigParser.h
@@ -26,7 +26,7 @@ namespace Config2 {
 
 class JsonConfigParser {
  public:
-  std::unique_ptr<IR::Root> parse(const std::string& input);
+  std::unique_ptr<IR::Root> parse(const std::string& input, const std::string& path);
 };
 
 } // namespace Config2

--- a/src/oomd/config/JsonConfigParserTest.cpp
+++ b/src/oomd/config/JsonConfigParserTest.cpp
@@ -35,7 +35,7 @@ TEST(JsonConfigParserTest, LoadIR) {
 
   // Make sure the IR was generated
   JsonConfigParser parser;
-  auto root = parser.parse(buffer.str());
+  auto root = parser.parse(buffer.str(), kConfig_1_0_0);
   ASSERT_TRUE(root);
 
   // Check root values
@@ -103,5 +103,5 @@ TEST(JsonConfigParserTest, LoadIR) {
 
 TEST(JsonConfigParserTest, LoadIRBadInput) {
   JsonConfigParser parser;
-  ASSERT_THROW(parser.parse("not a json string"), std::runtime_error);
+  ASSERT_THROW(parser.parse("not a json string","ignore"), std::runtime_error);
 }

--- a/src/oomd/dropin/FsDropInService.cpp
+++ b/src/oomd/dropin/FsDropInService.cpp
@@ -237,7 +237,7 @@ void FsDropInService::processDropInAdd(const std::string& file) {
   Config2::JsonConfigParser json_parser;
   std::unique_ptr<Config2::IR::Root> dropin_root;
   try {
-    dropin_root = json_parser.parse(buf.str());
+    dropin_root = json_parser.parse(buf.str(), file);
   } catch (const std::exception& e) {
     OLOG << "Caught: " << e.what();
     OLOG << "Failed to inject drop in config into engine";

--- a/src/oomd/engine/Ruleset.cpp
+++ b/src/oomd/engine/Ruleset.cpp
@@ -32,6 +32,7 @@ Ruleset::Ruleset(
     bool disable_on_drop_in,
     bool detectorgroups_dropin_enabled,
     bool actiongroup_dropin_enabled,
+    bool always_continue,
     uint32_t silence_logs,
     int post_action_delay,
     int prekill_hook_timeout,
@@ -47,6 +48,7 @@ Ruleset::Ruleset(
       disable_on_drop_in_(disable_on_drop_in),
       detectorgroups_dropin_enabled_(detectorgroups_dropin_enabled),
       actiongroup_dropin_enabled_(actiongroup_dropin_enabled),
+      always_continue_(always_continue),
       silenced_logs_(silence_logs),
       xattr_filter_(xattr_filter) {
   if (!cgroup.empty()) {
@@ -62,6 +64,7 @@ Ruleset::Ruleset(
     bool disable_on_drop_in,
     bool detectorgroups_dropin_enabled,
     bool actiongroup_dropin_enabled,
+    bool always_continue,
     uint32_t silence_logs,
     int post_action_delay,
     int prekill_hook_timeout,
@@ -74,6 +77,7 @@ Ruleset::Ruleset(
       disable_on_drop_in_(disable_on_drop_in),
       detectorgroups_dropin_enabled_(detectorgroups_dropin_enabled),
       actiongroup_dropin_enabled_(actiongroup_dropin_enabled),
+      always_continue_(always_continue),
       silenced_logs_(silence_logs) {
   cgroups_ = std::move(cgroups);
 }
@@ -236,7 +240,7 @@ uint32_t Ruleset::runOnceImpl(OomdContext& context) {
     }
   }
 
-  if (!run_actions) {
+  if (!run_actions && !always_continue_) {
     return 0;
   }
 
@@ -343,6 +347,7 @@ void Ruleset::registerRunnableRulesetForCgroupPath(
       disable_on_drop_in_,
       detectorgroups_dropin_enabled_,
       actiongroup_dropin_enabled_,
+      always_continue_,
       silenced_logs_,
       post_action_delay_,
       prekill_hook_timeout_,

--- a/src/oomd/engine/Ruleset.cpp
+++ b/src/oomd/engine/Ruleset.cpp
@@ -39,7 +39,8 @@ Ruleset::Ruleset(
     const std::string& xattr_filter,
     const std::string& cgroup_fs,
     // This is actually a comma separated list of cgroup glob patterns
-    const std::string& cgroup)
+    const std::string& cgroup,
+    std::unordered_map<std::string, int> kill_index)
     : name_(name),
       detector_groups_(std::move(detector_groups)),
       action_group_(std::move(action_group)),
@@ -50,7 +51,8 @@ Ruleset::Ruleset(
       actiongroup_dropin_enabled_(actiongroup_dropin_enabled),
       always_continue_(always_continue),
       silenced_logs_(silence_logs),
-      xattr_filter_(xattr_filter) {
+      xattr_filter_(xattr_filter),
+      kill_index_(std::move(kill_index)) {
   if (!cgroup.empty()) {
     cgroups_ = PluginArgParser::parseCgroup(
         PluginConstructionContext(cgroup_fs), cgroup);
@@ -68,7 +70,8 @@ Ruleset::Ruleset(
     uint32_t silence_logs,
     int post_action_delay,
     int prekill_hook_timeout,
-    std::unordered_set<CgroupPath> cgroups)
+    std::unordered_set<CgroupPath> cgroups,
+    std::unordered_map<std::string, int> kill_index)
     : name_(name),
       detector_groups_(std::move(detector_groups)),
       action_group_(std::move(action_group)),
@@ -78,7 +81,8 @@ Ruleset::Ruleset(
       detectorgroups_dropin_enabled_(detectorgroups_dropin_enabled),
       actiongroup_dropin_enabled_(actiongroup_dropin_enabled),
       always_continue_(always_continue),
-      silenced_logs_(silence_logs) {
+      silenced_logs_(silence_logs),
+      kill_index_(std::move(kill_index)) {
   cgroups_ = std::move(cgroups);
 }
 
@@ -200,12 +204,14 @@ uint32_t Ruleset::runOnceImpl(OomdContext& context) {
            std::chrono::steady_clock::now() +
                std::chrono::seconds(prekill_hook_timeout_)}),
           context.setInvokingRuleset(this);
+          context.setInvokingKillIndex(&this->kill_index_);
     }
   }
 
   OOMD_SCOPE_EXIT {
     context.setActionContext({"", "", "", std::nullopt});
     context.setInvokingRuleset(std::nullopt);
+    context.setInvokingKillIndex(std::nullopt);
     context.setRulesetCgroup(std::nullopt);
   };
 
@@ -351,7 +357,8 @@ void Ruleset::registerRunnableRulesetForCgroupPath(
       silenced_logs_,
       post_action_delay_,
       prekill_hook_timeout_,
-      std::unordered_set{CgroupPath(cgroup.cgroupFs(), cgroup.relativePath())});
+      std::unordered_set{CgroupPath(cgroup.cgroupFs(), cgroup.relativePath())},
+      kill_index_);
   ruleset->prerun(context);
   runnable_rulesets_[cgroup.absolutePath()] = std::move(ruleset);
 }

--- a/src/oomd/engine/Ruleset.h
+++ b/src/oomd/engine/Ruleset.h
@@ -38,6 +38,7 @@ class Ruleset {
       bool disable_on_drop_in = false,
       bool detectorgroups_dropin_enabled = false,
       bool actiongroup_dropin_enabled = false,
+      bool always_continue = false,
       uint32_t silenced_logs = 0,
       int post_action_delay = DEFAULT_POST_ACTION_DELAY,
       int prekill_hook_timeout = DEFAULT_PREKILL_HOOK_TIMEOUT,
@@ -51,6 +52,7 @@ class Ruleset {
       bool disable_on_drop_in,
       bool detectorgroups_dropin_enabled,
       bool actiongroup_dropin_enabled,
+      bool always_continue,
       uint32_t silenced_logs,
       int post_action_delay,
       int prekill_hook_timeout,
@@ -110,6 +112,7 @@ class Ruleset {
   bool disable_on_drop_in_{false};
   bool detectorgroups_dropin_enabled_{false};
   bool actiongroup_dropin_enabled_{false};
+  bool always_continue_{false};
   uint32_t silenced_logs_{0};
   int32_t numTargeted_{0};
   std::string xattr_filter_;

--- a/src/oomd/engine/Ruleset.h
+++ b/src/oomd/engine/Ruleset.h
@@ -44,7 +44,8 @@ class Ruleset {
       int prekill_hook_timeout = DEFAULT_PREKILL_HOOK_TIMEOUT,
       const std::string& xattr_filter = "",
       const std::string& cgroup_fs = "",
-      const std::string& cgroup = "");
+      const std::string& cgroup = "",
+      std::unordered_map<std::string, int> kill_index = {});
   Ruleset(
       const std::string& name,
       std::vector<std::unique_ptr<DetectorGroup>> detector_groups,
@@ -56,7 +57,8 @@ class Ruleset {
       uint32_t silenced_logs,
       int post_action_delay,
       int prekill_hook_timeout,
-      std::unordered_set<CgroupPath>);
+      std::unordered_set<CgroupPath> cgroups,
+      std::unordered_map<std::string, int> kill_index);
   ~Ruleset() = default;
 
   /*
@@ -118,6 +120,7 @@ class Ruleset {
   std::string xattr_filter_;
   std::optional<std::unordered_set<CgroupPath>> cgroups_{std::nullopt};
   std::unordered_map<std::string, std::unique_ptr<Ruleset>> runnable_rulesets_;
+  std::unordered_map<std::string, int> kill_index_;
 
   struct AsyncActionChainState {
    public:

--- a/src/oomd/include/CgroupPathTest.cpp
+++ b/src/oomd/include/CgroupPathTest.cpp
@@ -22,6 +22,7 @@
 
 #include "oomd/include/CgroupPath.h"
 #include "oomd/util/Fixture.h"
+#include "oomd/util/ScopeGuard.h"
 
 using namespace Oomd;
 
@@ -123,6 +124,9 @@ TEST(CgroupPathTest, HashTest) {
 TEST(CgroupPathTest, ResolveWildcardTest) {
   using F = Fixture;
   auto tempDir = F::mkdtempChecked();
+  OOMD_SCOPE_EXIT {
+    F::rmrChecked(tempDir);
+  };
   auto [name, fixture] = F::makeDir(
       "wildcard_root",
       {F::makeFile("a.txt", "content of a\n"),

--- a/src/oomd/plugins/AlwaysReclaim.cpp
+++ b/src/oomd/plugins/AlwaysReclaim.cpp
@@ -26,13 +26,12 @@ int AlwaysReclaim::init(
   return 0;
 }
 
-void AlwaysReclaim::reclaim_one(
-    const CgroupContext& target) {
+void AlwaysReclaim::reclaim_one(const CgroupContext& target) {
   auto ok = Fs::writeMemReclaimAt(target.fd(), reclaim_bytes_);
 
   std::ostringstream oss;
   oss << "cgroup=" << target.cgroup().relativePath()
-      << " reclaim_bytes=" << reclaim_bytes_ << " ok=" << (bool) ok;
+      << " reclaim_bytes=" << reclaim_bytes_ << " ok=" << (bool)ok;
   OLOG << oss.str();
 }
 

--- a/src/oomd/plugins/AlwaysReclaim.cpp
+++ b/src/oomd/plugins/AlwaysReclaim.cpp
@@ -17,7 +17,7 @@ int AlwaysReclaim::init(
         return PluginArgParser::parseCgroup(context, cgroupStr);
       },
       true);
-  argParser_.addArgument("reclaim_bytes", reclaim_bytes_);
+  argParser_.addArgument("reclaim_bytes", reclaim_bytes_, true);
 
   if (!argParser_.parse(args)) {
     return 1;

--- a/src/oomd/plugins/AlwaysReclaim.cpp
+++ b/src/oomd/plugins/AlwaysReclaim.cpp
@@ -1,0 +1,46 @@
+#include "oomd/plugins/AlwaysReclaim.h"
+
+#include "oomd/Log.h"
+#include "oomd/PluginRegistry.h"
+
+namespace Oomd {
+
+REGISTER_PLUGIN(always_reclaim, AlwaysReclaim::create);
+
+int AlwaysReclaim::init(
+    const Engine::PluginArgs& args,
+    const PluginConstructionContext& context) {
+  argParser_.addArgumentCustom(
+      "cgroup",
+      cgroups_,
+      [context](const std::string& cgroupStr) {
+        return PluginArgParser::parseCgroup(context, cgroupStr);
+      },
+      true);
+  argParser_.addArgument("reclaim_bytes", reclaim_bytes_);
+
+  if (!argParser_.parse(args)) {
+    return 1;
+  }
+
+  return 0;
+}
+
+void AlwaysReclaim::reclaim_one(
+    const CgroupContext& target) {
+  auto ok = Fs::writeMemReclaimAt(target.fd(), reclaim_bytes_);
+
+  std::ostringstream oss;
+  oss << "cgroup=" << target.cgroup().relativePath()
+      << " reclaim_bytes=" << reclaim_bytes_ << " ok=" << (bool) ok;
+  OLOG << oss.str();
+}
+
+Engine::PluginRet AlwaysReclaim::run(OomdContext& ctx) {
+  for (const auto& cgroupCtx : ctx.addToCacheAndGet(cgroups_))
+    reclaim_one(cgroupCtx);
+
+  return Engine::PluginRet::CONTINUE;
+}
+
+} // namespace Oomd

--- a/src/oomd/plugins/AlwaysReclaim.cpp
+++ b/src/oomd/plugins/AlwaysReclaim.cpp
@@ -17,6 +17,12 @@ int AlwaysReclaim::init(
         return PluginArgParser::parseCgroup(context, cgroupStr);
       },
       true);
+  argParser_.addArgumentCustom(
+      "ruleset_cgroup",
+      ruleset_cgroups_,
+      [context](const std::string& cgroupStr) {
+        return PluginArgParser::parseCgroup(context, cgroupStr);
+      });
   argParser_.addArgument("reclaim_bytes", reclaim_bytes_, true);
 
   if (!argParser_.parse(args)) {
@@ -36,7 +42,8 @@ void AlwaysReclaim::reclaim_one(const CgroupContext& target) {
 }
 
 Engine::PluginRet AlwaysReclaim::run(OomdContext& ctx) {
-  for (const auto& cgroupCtx : ctx.addToCacheAndGet(cgroups_))
+  for (const auto& cgroupCtx :
+       ctx.addToCacheAndGet(cgroups_, ruleset_cgroups_))
     reclaim_one(cgroupCtx);
 
   return Engine::PluginRet::CONTINUE;

--- a/src/oomd/plugins/AlwaysReclaim.h
+++ b/src/oomd/plugins/AlwaysReclaim.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "oomd/engine/BasePlugin.h"
+
+namespace Oomd {
+
+class AlwaysReclaim : public Engine::BasePlugin {
+ public:
+  int init(
+      const Engine::PluginArgs& args,
+      const PluginConstructionContext& /* unused */) override;
+
+  Engine::PluginRet run(OomdContext& ctx) override;
+
+  static AlwaysReclaim* create() {
+    return new AlwaysReclaim();
+  }
+
+  ~AlwaysReclaim() = default;
+
+ private:
+  void reclaim_one(const Oomd::CgroupContext&);
+
+  std::unordered_set<CgroupPath> cgroups_;
+  int64_t reclaim_bytes_{0};
+};
+
+} // namespace Oomd

--- a/src/oomd/plugins/AlwaysReclaim.h
+++ b/src/oomd/plugins/AlwaysReclaim.h
@@ -22,6 +22,7 @@ class AlwaysReclaim : public Engine::BasePlugin {
   void reclaim_one(const Oomd::CgroupContext&);
 
   std::unordered_set<CgroupPath> cgroups_;
+  std::unordered_set<CgroupPath> ruleset_cgroups_;
   int64_t reclaim_bytes_{0};
 };
 

--- a/src/oomd/plugins/CorePluginsTest.cpp
+++ b/src/oomd/plugins/CorePluginsTest.cpp
@@ -21,16 +21,17 @@
 #include <memory>
 #include <unordered_set>
 
+#include "oomd/ExitRegistry.h"
 #include "oomd/OomdContext.h"
 #include "oomd/PluginRegistry.h"
 #include "oomd/engine/BasePlugin.h"
+#include "oomd/engine/Ruleset.h"
 #include "oomd/plugins/BaseKillPlugin.h"
 #include "oomd/plugins/KillIOCost.h"
 #include "oomd/plugins/KillMemoryGrowth.h"
 #include "oomd/plugins/KillPgScan.h"
 #include "oomd/plugins/KillPressure.h"
 #include "oomd/plugins/KillSwapUsage.h"
-#include "oomd/plugins/Sleep.h"
 #include "oomd/util/Fixture.h"
 #include "oomd/util/TestHelper.h"
 
@@ -3371,7 +3372,9 @@ TEST_F(SleepTest, SleepTest) {
 
   EXPECT_EQ(plugin->run(ctx_), Engine::PluginRet::STOP);
 
-  plugin->start_ -= std::chrono::seconds(100);
+  auto start = TestHelper::getSleepStart(plugin);
+  start -= std::chrono::seconds(100);
+  TestHelper::setSleepStart(plugin, start);
 
   EXPECT_EQ(plugin->run(ctx_), Engine::PluginRet::CONTINUE);
 }
@@ -3418,4 +3421,101 @@ TEST_F(AlwaysReclaimTest , ReclaimMulti) {
       ctx_, CgroupPath(tempdir_, "reclaim_2")));
   auto reclaim2 = ASSERT_SYS_OK(Fs::readMemReclaimAt(target2.fd()));
   EXPECT_EQ(reclaim2, 1048576);
+}
+
+class InterdictTest : public CorePluginsTest {};
+
+TEST_F(InterdictTest , InterdictMulti) {
+#define initmh(x, y, z)                 \
+  F::materialize(F::makeDir(            \
+      tempdir_,                         \
+      {F::makeDir(                      \
+          "interdict_1",                \
+          {                             \
+              F::makeFile(              \
+                  Fs::kMemHighFile,     \
+                  x),                   \
+              }),                       \
+       F::makeDir(                      \
+          "interdict_2",                \
+          {                             \
+              F::makeFile(              \
+                  Fs::kMemHighFile,     \
+                  y),                   \
+              }),                       \
+       F::makeDir(                      \
+          "interdict_3",                \
+          {                             \
+              F::makeFile(              \
+                  Fs::kMemHighFile,     \
+                  z),                   \
+              }),                       \
+          }));
+
+  initmh("1", "2", "3");
+  const PluginConstructionContext compile_context(tempdir_);
+  std::vector<CgroupPath> keys = {
+      CgroupPath(compile_context.cgroupFs(), "interdict_1"),
+      CgroupPath(compile_context.cgroupFs(), "interdict_2"),
+      CgroupPath(compile_context.cgroupFs(), "interdict_3")
+  };
+
+  TestHelper::setCgroupData( ctx_, keys[0],
+      CgroupData{ .current_usage = 1024 * 1024 * 100});
+  TestHelper::setCgroupData( ctx_, keys[1],
+      CgroupData{ .current_usage = 1024 * 1024 * 100 * 2});
+  TestHelper::setCgroupData( ctx_, keys[2],
+      CgroupData{ .current_usage = 2048});
+
+  auto plugin = Interdict::create();
+  ASSERT_NE(plugin, nullptr);
+
+  Engine::PluginArgs args;
+  args["cgroup"] = "interdict_*";
+  args["memhigh_pct"] = "75";
+
+  ASSERT_EQ(plugin->init(std::move(args), compile_context), 0);
+
+  Engine::Ruleset ruleset_ = Engine::Ruleset{"foo", {}, {}};
+
+#define getmh(x) ASSERT_SYS_OK( \
+    Fs::readMemhighAt(ctx_.addToCacheAndGet(x)->get().fd()))
+
+  // active: memory.high <- memory.current * 0.75
+  initmh("max", "81920", "0");
+  ctx_.bumpCurrentTick();
+  ctx_.setInvokingRuleset(&ruleset_);
+  EXPECT_EQ(plugin->run(ctx_), Engine::PluginRet::CONTINUE);
+  EXPECT_EQ(TestHelper::getSavedSize(plugin), 3);
+  EXPECT_EQ(getmh(keys[0]), 1024 * 1024 * 75);
+  EXPECT_EQ(getmh(keys[1]), 1024 * 1024 * 75 * 2);
+  EXPECT_EQ(getmh(keys[2]), 4096);  // minimum value
+
+  // inactive: memory.high <- saved memory.high
+  initmh("1", "2", "3");
+  ctx_.bumpCurrentTick();
+  ctx_.setInvokingRuleset(std::nullopt);
+  EXPECT_EQ(plugin->run(ctx_), Engine::PluginRet::CONTINUE);
+  EXPECT_EQ(TestHelper::getSavedSize(plugin), 3);
+  EXPECT_EQ(getmh(keys[0]), std::numeric_limits<int64_t>::max());
+  EXPECT_EQ(getmh(keys[1]), 81920);
+  EXPECT_EQ(getmh(keys[2]), 4096);
+
+  // active: memory.high <- memory.current * 0.75
+  initmh("1", "2", "3");
+  TestHelper::setCurrentTick(ctx_, 128);
+  ctx_.setInvokingRuleset(&ruleset_);
+  TestHelper::dropCgroup(ctx_, keys[2]);
+  F::rmrChecked(keys[2].absolutePath());
+  EXPECT_EQ(plugin->run(ctx_), Engine::PluginRet::CONTINUE);
+  EXPECT_EQ(TestHelper::getSavedSize(plugin), 2);
+  EXPECT_EQ(getmh(keys[0]), 1024 * 1024 * 75);
+  EXPECT_EQ(getmh(keys[1]), 1024 * 1024 * 75 * 2);
+
+  // restore original values at exit
+  initmh("1", "2", "3");
+  getExitRegistry().callHooks();
+  EXPECT_EQ(getmh(keys[0]), std::numeric_limits<int64_t>::max());
+  EXPECT_EQ(getmh(keys[1]), 81920);
+  EXPECT_EQ(TestHelper::getSavedSize(plugin), 0);
 }

--- a/src/oomd/plugins/CorePluginsTest.cpp
+++ b/src/oomd/plugins/CorePluginsTest.cpp
@@ -33,6 +33,7 @@
 #include "oomd/plugins/KillPressure.h"
 #include "oomd/plugins/KillSwapUsage.h"
 #include "oomd/util/Fixture.h"
+#include "oomd/util/ScopeGuard.h"
 #include "oomd/util/TestHelper.h"
 
 using namespace Oomd;
@@ -3518,4 +3519,128 @@ TEST_F(InterdictTest , InterdictMulti) {
   EXPECT_EQ(getmh(keys[0]), std::numeric_limits<int64_t>::max());
   EXPECT_EQ(getmh(keys[1]), 81920);
   EXPECT_EQ(TestHelper::getSavedSize(plugin), 0);
+}
+
+class RunCommandTest : public CorePluginsTest {};
+
+TEST_F(RunCommandTest , RunCommandMissing) {
+  auto plugin = createPlugin("run_command");
+  ASSERT_NE(plugin, nullptr);
+
+  Engine::PluginArgs args;
+  args["command"] = "/no/such/file";
+  args["use_exit_value"] = "true";
+  const PluginConstructionContext compile_context("/sys/fs/cgroup");
+
+  ASSERT_EQ(plugin->init(std::move(args), compile_context), 0);
+
+  EXPECT_EQ(plugin->run(ctx_), Engine::PluginRet::STOP);
+
+  plugin = createPlugin("run_command");
+  ASSERT_NE(plugin, nullptr);
+
+  args["use_exit_value"] = "false";
+
+  ASSERT_EQ(plugin->init(std::move(args), compile_context), 0);
+
+  EXPECT_EQ(plugin->run(ctx_), Engine::PluginRet::CONTINUE);
+}
+
+TEST_F(RunCommandTest , RunCommandExits) {
+  auto plugin = createPlugin("run_command");
+  ASSERT_NE(plugin, nullptr);
+
+  Engine::PluginArgs args;
+  args["command"] = "/bin/true";
+  args["use_exit_value"] = "true";
+  const PluginConstructionContext compile_context("/sys/fs/cgroup");
+
+  ASSERT_EQ(plugin->init(std::move(args), compile_context), 0);
+
+  EXPECT_EQ(plugin->run(ctx_), Engine::PluginRet::CONTINUE);
+
+  plugin = createPlugin("run_command");
+  ASSERT_NE(plugin, nullptr);
+
+  args["command"] = "/bin/false";
+
+  ASSERT_EQ(plugin->init(std::move(args), compile_context), 0);
+
+  EXPECT_EQ(plugin->run(ctx_), Engine::PluginRet::STOP);
+}
+
+TEST_F(RunCommandTest , RunCommandCache) {
+  char wd[PATH_MAX];
+  ASSERT_NE(nullptr, getcwd(wd, sizeof(wd)));
+  OOMD_SCOPE_EXIT { ASSERT_EQ(0, chdir(wd)); };
+  ASSERT_EQ(0, chdir(tempdir_.c_str()));
+
+  // create script that touches a new file at each invocation
+  ASSERT_EQ(0, std::system("echo 'touch go.$$' > go && chmod u+x go"));
+
+  auto plugin = createPlugin("run_command");
+  ASSERT_NE(plugin, nullptr);
+
+  Engine::PluginArgs args;
+  args["command"] = tempdir_ + "/go";
+  args["use_exit_value"] = "true";
+  const PluginConstructionContext compile_context("/sys/fs/cgroup");
+
+  ASSERT_EQ(plugin->init(std::move(args), compile_context), 0);
+
+  EXPECT_EQ(plugin->run(ctx_), Engine::PluginRet::CONTINUE);
+  EXPECT_EQ(plugin->run(ctx_), Engine::PluginRet::CONTINUE);
+
+  // count invocations
+  EXPECT_EQ(2, WEXITSTATUS(
+        std::system("rc=`ls go.* | grep -c .`; rm -f go.*; exit $rc")));
+
+  plugin = createPlugin("run_command");
+  ASSERT_NE(plugin, nullptr);
+
+  args["cache_sec"] = "100";
+
+  ASSERT_EQ(plugin->init(std::move(args), compile_context), 0);
+
+  EXPECT_EQ(plugin->run(ctx_), Engine::PluginRet::CONTINUE);
+  EXPECT_EQ(plugin->run(ctx_), Engine::PluginRet::CONTINUE);
+  EXPECT_EQ(plugin->run(ctx_), Engine::PluginRet::CONTINUE);
+
+  EXPECT_EQ(1, WEXITSTATUS(
+        std::system("rc=`ls go.* | grep -c .`; rm -f go.*; exit $rc")));
+}
+
+TEST_F(RunCommandTest , RunCommandTimeout) {
+  char wd[PATH_MAX];
+  ASSERT_NE(nullptr, getcwd(wd, sizeof(wd)));
+  OOMD_SCOPE_EXIT { ASSERT_EQ(0, chdir(wd)); };
+  ASSERT_EQ(0, chdir(tempdir_.c_str()));
+
+  // create script that touches a new file at each invocation
+  ASSERT_EQ(0, std::system("echo 'sleep $*' > go && chmod u+x go"));
+
+  auto plugin = RunCommand::create();
+  ASSERT_NE(plugin, nullptr);
+
+  Engine::PluginArgs args;
+  args["command"] = tempdir_ + "/go";
+  args["use_exit_value"] = "true";
+  args["argument"] = "0.01\t0.01\t0.01";
+  args["timeout_msec"] = "50";
+  const PluginConstructionContext compile_context("/sys/fs/cgroup");
+
+  ASSERT_EQ(plugin->init(std::move(args), compile_context), 0);
+  // c_args_ contains the command, the args, and a trailing NULL
+  EXPECT_EQ(5, TestHelper::getArgsSize(plugin));
+
+  EXPECT_EQ(plugin->run(ctx_), Engine::PluginRet::CONTINUE);
+
+  args["argument"] = "1";
+  plugin = RunCommand::create();
+  ASSERT_NE(plugin, nullptr);
+
+  ASSERT_EQ(plugin->init(std::move(args), compile_context), 0);
+  EXPECT_EQ(3, TestHelper::getArgsSize(plugin));
+
+  EXPECT_EQ(plugin->run(ctx_), Engine::PluginRet::STOP);
 }

--- a/src/oomd/plugins/CorePluginsTest.cpp
+++ b/src/oomd/plugins/CorePluginsTest.cpp
@@ -239,9 +239,9 @@ TEST_F(BaseKillPluginXattrTest, XattrSetts) {
 class AlphabeticStandardKillPlugin : public BaseKillPluginMock {
  public:
   std::vector<OomdContext::ConstCgroupContextRef> rankForKilling(
-      OomdContext& /* unused */,
+      OomdContext& ctx,
       const std::vector<OomdContext::ConstCgroupContextRef>& cgroups) override {
-    return OomdContext::sortDescWithKillPrefs(
+    return OomdContext::sortDescWithKillValue(ctx,
         cgroups, [](const CgroupContext& cgroup_ctx) {
           return cgroup_ctx.cgroup().relativePathParts().back();
         });
@@ -443,9 +443,9 @@ TEST_F(StandardKillRecursionTest, RespectsMemoryOomGroup) {
 
 TEST_F(StandardKillRecursionTest, RespectsPreferAvoid) {
   // Technically not an aspect of BaseKillPlugin, and implemented
-  // separately in each subclass with OomdContext::sortDescWithKillPrefs in
+  // separately in each subclass with OomdContext::sortDescWithKillValue in
   // the subclass' rankForKilling.  It's expected that all subclasses will
-  // use OomdContext::sortDescWithKillPrefs in the same way, so we test an ex
+  // use OomdContext::sortDescWithKillValue in the same way, so we test an ex
   // of it here.
 
   F::materialize(
@@ -497,6 +497,16 @@ TEST_F(StandardKillRecursionTest, RespectsPreferAvoid) {
             CgroupPath(tempdir_, expected_victim).absolutePath());
       };
 
+  // establish base case - chose max letter at each level
+  expect_to_kill("test.slice/Q/F/P", [&](auto& ctx) { return; });
+
+  expect_to_kill("test.slice/B/M/Z", [&](auto& ctx) {
+    TestHelper::setCgroupData(
+        ctx,
+        CgroupPath(tempdir_, "test.slice/Q"),
+        CgroupData{.kill_preference = KillPreference::AVOID});
+  });
+
   expect_to_kill("test.slice/B/M/V", [&](auto& ctx) {
     TestHelper::setCgroupData(
         ctx,
@@ -508,8 +518,8 @@ TEST_F(StandardKillRecursionTest, RespectsPreferAvoid) {
         CgroupData{.kill_preference = KillPreference::PREFER});
   });
 
-  // Test locality of prefs. Even though Y/M/X is PREFER, it's not chosen
-  // because Q is chosen over Y in the first level of the tree.
+  // Test locality of prefs. Even though B/M/V is PREFER, it's not chosen
+  // because Q is chosen over B in the first level of the tree.
   // Q/F/P is selected despite being the only AVOID in a tree with a PREFER.
   expect_to_kill("test.slice/Q/F/P", [&](auto& ctx) {
     TestHelper::setCgroupData(
@@ -532,6 +542,36 @@ TEST_F(StandardKillRecursionTest, RespectsPreferAvoid) {
         ctx,
         CgroupPath(tempdir_, "test.slice/B/M/Z"),
         CgroupData{.kill_preference = KillPreference::AVOID});
+  });
+
+  // Preserve the Q branch
+  std::unordered_map<std::string, int> kvp = {{ "test.slice/Q", -1 }};
+  expect_to_kill("test.slice/B/M/Z", [&](auto& ctx) {
+    ctx.setInvokingKillIndex(&kvp);
+  });
+
+  // Prefer to kill B/M/V over B/M/Z (default of 0)
+  kvp["test.slice/B/M/V"] = 99;
+  expect_to_kill("test.slice/B/M/V", [&](auto& ctx) {
+    ctx.setInvokingKillIndex(&kvp);
+  });
+
+  // Set B/M/Z equal to B/M/V, fall back to descending alphabetical order
+  kvp["test.slice/B/M/Z"] = 99;
+  expect_to_kill("test.slice/B/M/Z", [&](auto& ctx) {
+    ctx.setInvokingKillIndex(&kvp);
+  });
+
+  // Explicitly set B/M/Z below B/M/V
+  kvp["test.slice/B/M/Z"] = 98;
+  expect_to_kill("test.slice/B/M/V", [&](auto& ctx) {
+    ctx.setInvokingKillIndex(&kvp);
+  });
+
+  // Preserve B/M
+  kvp["test.slice/B/M"] = -1;
+  expect_to_kill("test.slice/A/Z", [&](auto& ctx) {
+    ctx.setInvokingKillIndex(&kvp);
   });
 }
 

--- a/src/oomd/plugins/CorePluginsTest.cpp
+++ b/src/oomd/plugins/CorePluginsTest.cpp
@@ -30,6 +30,7 @@
 #include "oomd/plugins/KillPgScan.h"
 #include "oomd/plugins/KillPressure.h"
 #include "oomd/plugins/KillSwapUsage.h"
+#include "oomd/plugins/Sleep.h"
 #include "oomd/util/Fixture.h"
 #include "oomd/util/TestHelper.h"
 
@@ -3354,4 +3355,67 @@ TEST_F(StopTest, Stops) {
   ASSERT_EQ(plugin->init(std::move(args), compile_context), 0);
 
   EXPECT_EQ(plugin->run(ctx_), Engine::PluginRet::STOP);
+}
+
+class SleepTest : public CorePluginsTest {};
+
+TEST_F(SleepTest, SleepTest) {
+  auto plugin = Sleep::create();
+  ASSERT_NE(plugin, nullptr);
+
+  Engine::PluginArgs args;
+  args["duration"] = "100";
+  const PluginConstructionContext compile_context("/sys/fs/cgroup");
+
+  ASSERT_EQ(plugin->init(std::move(args), compile_context), 0);
+
+  EXPECT_EQ(plugin->run(ctx_), Engine::PluginRet::STOP);
+
+  plugin->start_ -= std::chrono::seconds(100);
+
+  EXPECT_EQ(plugin->run(ctx_), Engine::PluginRet::CONTINUE);
+}
+
+class AlwaysReclaimTest : public CorePluginsTest {};
+
+TEST_F(AlwaysReclaimTest , ReclaimMulti) {
+  F::materialize(F::makeDir(
+      tempdir_,
+      {F::makeDir(
+          "reclaim_1",
+          {
+              F::makeFile(
+                  Fs::kMemReclaimFile,
+                  "0\n"),
+              }),
+       F::makeDir(
+          "reclaim_2",
+          {
+              F::makeFile(
+                  Fs::kMemReclaimFile,
+                  "0\n"),
+              }),
+          }));
+
+  auto plugin = createPlugin("always_reclaim");
+  ASSERT_NE(plugin, nullptr);
+
+  Engine::PluginArgs args;
+  args["cgroup"] = "reclaim_1,reclaim_2";
+  args["reclaim_bytes"] = "1048576";
+  const PluginConstructionContext compile_context(tempdir_);
+
+  ASSERT_EQ(plugin->init(std::move(args), compile_context), 0);
+
+  EXPECT_EQ(plugin->run(ctx_), Engine::PluginRet::CONTINUE);
+
+  auto target1 = ASSERT_EXISTS(CgroupContext::make(
+      ctx_, CgroupPath(tempdir_, "reclaim_1")));
+  auto reclaim1 = ASSERT_SYS_OK(Fs::readMemReclaimAt(target1.fd()));
+  EXPECT_EQ(reclaim1, 1048576);
+
+  auto target2 = ASSERT_EXISTS(CgroupContext::make(
+      ctx_, CgroupPath(tempdir_, "reclaim_2")));
+  auto reclaim2 = ASSERT_SYS_OK(Fs::readMemReclaimAt(target2.fd()));
+  EXPECT_EQ(reclaim2, 1048576);
 }

--- a/src/oomd/plugins/Interdict.cpp
+++ b/src/oomd/plugins/Interdict.cpp
@@ -1,0 +1,109 @@
+#include "oomd/plugins/Interdict.h"
+
+#include "oomd/Log.h"
+#include "oomd/PluginRegistry.h"
+#include "oomd/ExitRegistry.h"
+
+namespace Oomd {
+
+REGISTER_PLUGIN(interdict, Interdict::create);
+
+int Interdict::init(
+    const Engine::PluginArgs& args,
+    const PluginConstructionContext& context) {
+  argParser_.addArgumentCustom(
+      "cgroup",
+      cgroups_,
+      [context](const std::string& cgroupStr) {
+        return PluginArgParser::parseCgroup(context, cgroupStr);
+      },
+      true);
+  int64_t pct;
+  argParser_.addArgument("memhigh_pct", pct, true);
+
+  if (!argParser_.parse(args)) {
+    return 1;
+  }
+
+  if (pct < 1 || pct > 99) {
+    OLOG << "Percentage not between 0 and 100: " << pct;
+    return 1;
+  }
+
+  // convert to 128-based percentage to use bit shifts instead of division
+  memhigh_factor_ = (pct * 128) / 100;
+
+  REGISTER_EXIT_HOOK(interdict, [this]() { reset(); });
+
+  return 0;
+}
+
+std::string int2str(int64_t i) {
+  return i == std::numeric_limits<int64_t>::max() ? "max" : std::to_string(i);
+}
+
+void Interdict::interdict_one(
+    const CgroupContext& ctx,
+    bool activate,
+    const uint64_t tick,
+    std::ostringstream& oss) {
+  oss << "cgroup=" << ctx.cgroup().relativePath();
+
+  const auto id = ctx.id().value();
+  auto& s = saved_[id];
+  if (s.tick == 0) {
+    s.memhigh = ctx.memory_high().value_or(0);
+    s.dir = &ctx.fd();
+    oss << " saved=" << int2str(s.memhigh);
+  }
+  s.tick = tick;
+
+  const auto current = ctx.current_usage().value_or(0);
+  oss << " current=" << current;
+  int64_t limit = activate ? (current >> 7) * memhigh_factor_ : s.memhigh;
+  if (limit < 4096)
+    limit = 4096;
+
+  if (! (activate ^ s.isActive)) {
+    oss << " noop" << " isActive=" << s.isActive;
+    return;
+  }
+
+  if (const auto ret = Fs::writeMemhighAt(ctx.fd(), limit); !ret) {
+    oss << " " << ret.error().what();
+    return;
+  }
+
+  s.isActive = !s.isActive;
+
+  oss << " memory.high=" << int2str(limit) << " isActive=" << s.isActive;
+}
+
+Engine::PluginRet Interdict::run(OomdContext& ctx) {
+  const auto activate = ctx.getInvokingRuleset().has_value();
+  const auto tick = ctx.getCurrentTick();
+
+  for (const auto& cgroupCtx : ctx.addToCacheAndGet(cgroups_)) {
+    std::ostringstream oss;
+    interdict_one(cgroupCtx, activate, tick, oss);
+    OLOG << oss.str();
+  }
+
+  // purge data for removed/replaced cgroups periodically
+  if (tick % 128 == 0) {
+    for (auto it = saved_.begin(); it != saved_.end(); ) {
+      it = it->second.tick == tick ? std::next(it) : saved_.erase(it);
+    }
+  }
+
+  return Engine::PluginRet::CONTINUE;
+}
+
+void Interdict::reset() {
+  for (auto it = saved_.begin(); it != saved_.end(); it = saved_.erase(it)) {
+    auto& s = it->second;
+    Fs::writeMemhighAt(*s.dir, s.memhigh);
+  }
+}
+
+} // namespace Oomd

--- a/src/oomd/plugins/Interdict.cpp
+++ b/src/oomd/plugins/Interdict.cpp
@@ -1,8 +1,8 @@
 #include "oomd/plugins/Interdict.h"
 
+#include "oomd/ExitRegistry.h"
 #include "oomd/Log.h"
 #include "oomd/PluginRegistry.h"
-#include "oomd/ExitRegistry.h"
 
 namespace Oomd {
 
@@ -64,7 +64,7 @@ void Interdict::interdict_one(
   if (limit < 4096)
     limit = 4096;
 
-  if (! (activate ^ s.isActive)) {
+  if (!(activate ^ s.isActive)) {
     oss << " noop" << " isActive=" << s.isActive;
     return;
   }
@@ -91,7 +91,7 @@ Engine::PluginRet Interdict::run(OomdContext& ctx) {
 
   // purge data for removed/replaced cgroups periodically
   if (tick % 128 == 0) {
-    for (auto it = saved_.begin(); it != saved_.end(); ) {
+    for (auto it = saved_.begin(); it != saved_.end();) {
       it = it->second.tick == tick ? std::next(it) : saved_.erase(it);
     }
   }

--- a/src/oomd/plugins/Interdict.cpp
+++ b/src/oomd/plugins/Interdict.cpp
@@ -18,6 +18,12 @@ int Interdict::init(
         return PluginArgParser::parseCgroup(context, cgroupStr);
       },
       true);
+  argParser_.addArgumentCustom(
+      "ruleset_cgroup",
+      ruleset_cgroups_,
+      [context](const std::string& cgroupStr) {
+        return PluginArgParser::parseCgroup(context, cgroupStr);
+      });
   int64_t pct;
   argParser_.addArgument("memhigh_pct", pct, true);
 
@@ -83,7 +89,8 @@ Engine::PluginRet Interdict::run(OomdContext& ctx) {
   const auto activate = ctx.getInvokingRuleset().has_value();
   const auto tick = ctx.getCurrentTick();
 
-  for (const auto& cgroupCtx : ctx.addToCacheAndGet(cgroups_)) {
+  for (const auto& cgroupCtx :
+       ctx.addToCacheAndGet(cgroups_, ruleset_cgroups_)) {
     std::ostringstream oss;
     interdict_one(cgroupCtx, activate, tick, oss);
     OLOG << oss.str();

--- a/src/oomd/plugins/Interdict.h
+++ b/src/oomd/plugins/Interdict.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "oomd/engine/BasePlugin.h"
+
+namespace Oomd {
+
+class Interdict : public Engine::BasePlugin {
+ public:
+  int init(
+      const Engine::PluginArgs& args,
+      const PluginConstructionContext& /* unused */) override;
+
+  Engine::PluginRet run(OomdContext& ctx) override;
+
+  static Interdict* create() {
+    return new Interdict();
+  }
+
+  ~Interdict() = default;
+
+ private:
+  // Test only
+  friend class TestHelper;
+
+  struct SavedMemhigh {
+    SavedMemhigh() : memhigh{0}, isActive{false}, tick{0}, dir{nullptr} {}
+
+    int64_t memhigh;
+    bool isActive;
+    uint64_t tick;
+    const Fs::DirFd* dir;
+  };
+  std::unordered_map<uint64_t, SavedMemhigh> saved_;
+
+  void interdict_one(
+      const Oomd::CgroupContext&,
+      bool activate,
+      uint64_t tick,
+      std::ostringstream& oss);
+
+  void reset();
+
+  std::unordered_set<CgroupPath> cgroups_;
+  int64_t memhigh_factor_{0};
+};
+
+} // namespace Oomd

--- a/src/oomd/plugins/Interdict.h
+++ b/src/oomd/plugins/Interdict.h
@@ -41,6 +41,7 @@ class Interdict : public Engine::BasePlugin {
   void reset();
 
   std::unordered_set<CgroupPath> cgroups_;
+  std::unordered_set<CgroupPath> ruleset_cgroups_;
   int64_t memhigh_factor_{0};
 };
 

--- a/src/oomd/plugins/KillIOCost-inl.h
+++ b/src/oomd/plugins/KillIOCost-inl.h
@@ -40,7 +40,7 @@ std::vector<OomdContext::ConstCgroupContextRef>
 KillIOCost<Base>::rankForKilling(
     OomdContext& ctx,
     const std::vector<OomdContext::ConstCgroupContextRef>& cgroups) {
-  return OomdContext::sortDescWithKillPrefs(ctx,
+  return OomdContext::sortDescWithKillValue(ctx,
       cgroups, [](const CgroupContext& cgroup_ctx) {
         return cgroup_ctx.io_cost_rate().value_or(0);
       });

--- a/src/oomd/plugins/KillIOCost-inl.h
+++ b/src/oomd/plugins/KillIOCost-inl.h
@@ -40,7 +40,7 @@ std::vector<OomdContext::ConstCgroupContextRef>
 KillIOCost<Base>::rankForKilling(
     OomdContext& ctx,
     const std::vector<OomdContext::ConstCgroupContextRef>& cgroups) {
-  return OomdContext::sortDescWithKillPrefs(
+  return OomdContext::sortDescWithKillPrefs(ctx,
       cgroups, [](const CgroupContext& cgroup_ctx) {
         return cgroup_ctx.io_cost_rate().value_or(0);
       });

--- a/src/oomd/plugins/KillMemoryGrowth-inl.h
+++ b/src/oomd/plugins/KillMemoryGrowth-inl.h
@@ -139,7 +139,7 @@ KillMemoryGrowth<Base>::rankForKilling(
 
   // Note kill_preference take priority over phase, which is
   // handled automatically by sortDescWithKillPrefs.
-  return OomdContext::sortDescWithKillPrefs(
+  return OomdContext::sortDescWithKillPrefs(ctx,
       cgroups, [&](const CgroupContext& cgroup_ctx) {
         return rank_cgroup(cgroup_ctx).second;
       });

--- a/src/oomd/plugins/KillMemoryGrowth-inl.h
+++ b/src/oomd/plugins/KillMemoryGrowth-inl.h
@@ -138,8 +138,8 @@ KillMemoryGrowth<Base>::rankForKilling(
   auto rank_cgroup = get_ranking_fn(ctx, cgroups);
 
   // Note kill_preference take priority over phase, which is
-  // handled automatically by sortDescWithKillPrefs.
-  return OomdContext::sortDescWithKillPrefs(ctx,
+  // handled automatically by sortDescWithKillValue.
+  return OomdContext::sortDescWithKillValue(ctx,
       cgroups, [&](const CgroupContext& cgroup_ctx) {
         return rank_cgroup(cgroup_ctx).second;
       });

--- a/src/oomd/plugins/KillPgScan-inl.h
+++ b/src/oomd/plugins/KillPgScan-inl.h
@@ -76,7 +76,7 @@ KillPgScan<Base>::rankForKilling(
     }
   }
 
-  return OomdContext::sortDescWithKillPrefs(
+  return OomdContext::sortDescWithKillPrefs(ctx,
       Util::filter(
           cgroups,
           [=](const CgroupContext& cgroup_ctx) {

--- a/src/oomd/plugins/KillPgScan-inl.h
+++ b/src/oomd/plugins/KillPgScan-inl.h
@@ -76,7 +76,7 @@ KillPgScan<Base>::rankForKilling(
     }
   }
 
-  return OomdContext::sortDescWithKillPrefs(ctx,
+  return OomdContext::sortDescWithKillValue(ctx,
       Util::filter(
           cgroups,
           [=](const CgroupContext& cgroup_ctx) {

--- a/src/oomd/plugins/KillPressure-inl.h
+++ b/src/oomd/plugins/KillPressure-inl.h
@@ -42,7 +42,7 @@ std::vector<OomdContext::ConstCgroupContextRef>
 KillPressure<Base>::rankForKilling(
     OomdContext& ctx,
     const std::vector<OomdContext::ConstCgroupContextRef>& cgroups) {
-  return OomdContext::sortDescWithKillPrefs(ctx,
+  return OomdContext::sortDescWithKillValue(ctx,
       cgroups, [&](const CgroupContext& cgroup_ctx) {
         int average = 0;
         switch (resource_) {

--- a/src/oomd/plugins/KillPressure-inl.h
+++ b/src/oomd/plugins/KillPressure-inl.h
@@ -42,7 +42,7 @@ std::vector<OomdContext::ConstCgroupContextRef>
 KillPressure<Base>::rankForKilling(
     OomdContext& ctx,
     const std::vector<OomdContext::ConstCgroupContextRef>& cgroups) {
-  return OomdContext::sortDescWithKillPrefs(
+  return OomdContext::sortDescWithKillPrefs(ctx,
       cgroups, [&](const CgroupContext& cgroup_ctx) {
         int average = 0;
         switch (resource_) {

--- a/src/oomd/plugins/KillSwapUsage-inl.h
+++ b/src/oomd/plugins/KillSwapUsage-inl.h
@@ -86,7 +86,7 @@ std::vector<OomdContext::ConstCgroupContextRef>
 KillSwapUsage<Base>::rankForKilling(
     OomdContext& ctx,
     const std::vector<OomdContext::ConstCgroupContextRef>& cgroups) {
-  return OomdContext::sortDescWithKillPrefs(
+  return OomdContext::sortDescWithKillPrefs(ctx,
       Util::filter(
           cgroups,
           [=, this](const CgroupContext& cgroup_ctx) {

--- a/src/oomd/plugins/KillSwapUsage-inl.h
+++ b/src/oomd/plugins/KillSwapUsage-inl.h
@@ -86,7 +86,7 @@ std::vector<OomdContext::ConstCgroupContextRef>
 KillSwapUsage<Base>::rankForKilling(
     OomdContext& ctx,
     const std::vector<OomdContext::ConstCgroupContextRef>& cgroups) {
-  return OomdContext::sortDescWithKillPrefs(ctx,
+  return OomdContext::sortDescWithKillValue(ctx,
       Util::filter(
           cgroups,
           [=, this](const CgroupContext& cgroup_ctx) {

--- a/src/oomd/plugins/RunCommand.cpp
+++ b/src/oomd/plugins/RunCommand.cpp
@@ -1,0 +1,111 @@
+#include "oomd/plugins/RunCommand.h"
+
+#include <signal.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <cstring>
+#include <future>
+
+#include "oomd/Log.h"
+#include "oomd/PluginRegistry.h"
+#include "oomd/util/SystemMaybe.h"
+
+namespace Oomd {
+
+REGISTER_PLUGIN(run_command, RunCommand::create);
+
+int RunCommand::init(
+    const Engine::PluginArgs& pluginArgs,
+    const PluginConstructionContext& context) {
+  std::string wholeArg;
+
+  argParser_.addArgument("command", command_, true);
+  argParser_.addArgument("use_exit_value", useExitValue_);
+  argParser_.addArgument("cache_sec", cacheSec_);
+  argParser_.addArgument("timeout_msec", timeoutMsec_);
+  argParser_.addArgument("argument", wholeArg);
+
+  if (!argParser_.parse(pluginArgs)) {
+    return 1;
+  }
+
+  args_ = Util::split(wholeArg, '\t');
+
+  c_args_.emplace_back(const_cast<char*>(command_.c_str()));
+  for (auto& s : args_)
+    c_args_.emplace_back(const_cast<char*>(s.c_str()));
+  c_args_.emplace_back(nullptr);
+
+  return 0;
+}
+
+// Fork and execute the command with a timeout
+SystemMaybe<int> RunCommand::forkexec() {
+  pid_t pid = fork();
+  if (pid == -1)
+    return systemError(errno, "Failed to fork");
+
+  if (pid == 0) {
+    // Child process
+    execvp(c_args_[0], c_args_.data());
+    _Exit(EXIT_FAILURE); // If execvp fails
+  }
+
+  // Parent process: Wait for the child process with a timeout
+  std::promise<int> result;
+  std::future<int> future = result.get_future();
+
+  std::thread waitThread([pid, &result]() {
+    int status;
+    waitpid(pid, &status, 0);
+    result.set_value(status);
+  });
+
+  if (future.wait_for(timeoutMsec_) == std::future_status::timeout) {
+    // Timeout occurred
+    kill(pid, SIGKILL); // Kill the child process
+    waitThread.join();
+    return systemError(ECANCELED, "Timeout waiting for child process");
+  }
+
+  waitThread.join();
+  int status = future.get();
+  if (status == -1)
+    return systemError(status, "Failed to wait for child process");
+
+  return status;
+}
+
+Engine::PluginRet RunCommand::run(OomdContext& ctx) {
+  using std::chrono::steady_clock;
+
+  const auto now = steady_clock::now();
+  const auto diff =
+      std::chrono::duration_cast<std::chrono::seconds>(now - start_).count();
+  if (diff < cacheSec_) {
+    const auto s = ret_ == Engine::PluginRet::CONTINUE ? "CONTINUE" : "STOP";
+    OLOG << "using cached result; diff=" << diff << " ret=" << s;
+    return ret_; // Skip execution if within cache time
+  }
+
+  start_ = now;
+
+  const auto maybe = forkexec();
+  if (!maybe) {
+    OLOG << maybe.error().what();
+    return ret_ = useExitValue_ ? Engine::PluginRet::STOP
+                                : Engine::PluginRet::CONTINUE;
+  }
+
+  ret_ = useExitValue_ && (!WIFEXITED(*maybe) || WEXITSTATUS(*maybe) != 0)
+      ? Engine::PluginRet::STOP // Non-zero exit value or killed
+      : Engine::PluginRet::CONTINUE;
+
+  const auto s = ret_ == Engine::PluginRet::CONTINUE ? "CONTINUE" : "STOP";
+  OLOG << "use_exit_value=" << useExitValue_ << " status=" << *maybe
+       << " exit=" << WEXITSTATUS(*maybe) << " ret=" << s;
+  return ret_;
+}
+
+} // namespace Oomd

--- a/src/oomd/plugins/RunCommand.h
+++ b/src/oomd/plugins/RunCommand.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <chrono>
+
+#include "oomd/engine/BasePlugin.h"
+
+namespace Oomd {
+
+class RunCommand : public Engine::BasePlugin {
+ public:
+  int init(
+      const Engine::PluginArgs& args,
+      const PluginConstructionContext& /* unused */) override;
+
+  Engine::PluginRet run(OomdContext& /* unused */) override;
+
+  static RunCommand* create() {
+    return new RunCommand();
+  }
+
+  ~RunCommand() = default;
+
+ private:
+  // Test only
+  friend class TestHelper;
+
+  SystemMaybe<int> forkexec();
+
+  std::string command_;
+  int64_t cacheSec_{0}; // Default to no caching
+  std::chrono::milliseconds timeoutMsec_{std::chrono::milliseconds(500)};
+  bool useExitValue_{false};
+  std::chrono::time_point<std::chrono::steady_clock> start_{};
+  Engine::PluginRet ret_;
+  std::vector<std::string> args_;
+  std::vector<char*> c_args_;
+};
+
+} // namespace Oomd

--- a/src/oomd/plugins/Sleep.cpp
+++ b/src/oomd/plugins/Sleep.cpp
@@ -36,11 +36,8 @@ Engine::PluginRet Sleep::run(OomdContext& ctx) {
     ret = Engine::PluginRet::CONTINUE;
   }
 
-#ifdef DEBUG
-  std::ostringstream oss;
-  oss << "duration=" << duration_ << " diff=" << diff << " ret=" << (int)ret;
-  OLOG << oss.str();
-#endif
+  const auto s = ret == Engine::PluginRet::CONTINUE ? "CONTINUE" : "STOP";
+  OLOG << "duration=" << duration_ << " diff=" << diff << " ret=" << s;
 
   return ret;
 }

--- a/src/oomd/plugins/Sleep.cpp
+++ b/src/oomd/plugins/Sleep.cpp
@@ -29,8 +29,7 @@ Engine::PluginRet Sleep::run(OomdContext& ctx) {
   auto ret = Engine::PluginRet::STOP;
   const auto now = steady_clock::now();
   const auto diff =
-      std::chrono::duration_cast<std::chrono::seconds>(now - start_)
-          .count();
+      std::chrono::duration_cast<std::chrono::seconds>(now - start_).count();
 
   if (diff >= duration_) {
     start_ = steady_clock::now();
@@ -39,8 +38,7 @@ Engine::PluginRet Sleep::run(OomdContext& ctx) {
 
 #ifdef DEBUG
   std::ostringstream oss;
-  oss << "duration=" << duration_ << " diff=" << diff
-      << " ret=" << (int) ret;
+  oss << "duration=" << duration_ << " diff=" << diff << " ret=" << (int)ret;
   OLOG << oss.str();
 #endif
 

--- a/src/oomd/plugins/Sleep.cpp
+++ b/src/oomd/plugins/Sleep.cpp
@@ -1,0 +1,50 @@
+#include "oomd/plugins/Sleep.h"
+
+#include "oomd/Log.h"
+#include "oomd/PluginRegistry.h"
+
+namespace Oomd {
+
+REGISTER_PLUGIN(sleep, Sleep::create);
+
+int Sleep::init(
+    const Engine::PluginArgs& args,
+    const PluginConstructionContext& context) {
+  using std::chrono::steady_clock;
+
+  argParser_.addArgument("duration", duration_, true);
+  if (!argParser_.parse(args)) {
+    return 1;
+  }
+
+  start_ = steady_clock::now();
+
+  // Success
+  return 0;
+}
+
+Engine::PluginRet Sleep::run(OomdContext& ctx) {
+  using std::chrono::steady_clock;
+
+  auto ret = Engine::PluginRet::STOP;
+  const auto now = steady_clock::now();
+  const auto diff =
+      std::chrono::duration_cast<std::chrono::seconds>(now - start_)
+          .count();
+
+  if (diff >= duration_) {
+    start_ = steady_clock::now();
+    ret = Engine::PluginRet::CONTINUE;
+  }
+
+#ifdef DEBUG
+  std::ostringstream oss;
+  oss << "duration=" << duration_ << " diff=" << diff
+      << " ret=" << (int) ret;
+  OLOG << oss.str();
+#endif
+
+  return ret;
+}
+
+} // namespace Oomd

--- a/src/oomd/plugins/Sleep.h
+++ b/src/oomd/plugins/Sleep.h
@@ -20,10 +20,11 @@ class Sleep : public Engine::BasePlugin {
 
   ~Sleep() = default;
 
+  // public for unit test
+  std::chrono::steady_clock::time_point start_{};
+
   private:
     int duration_;
-
-    std::chrono::steady_clock::time_point start_{};
 };
 
 } // namespace Oomd

--- a/src/oomd/plugins/Sleep.h
+++ b/src/oomd/plugins/Sleep.h
@@ -20,11 +20,12 @@ class Sleep : public Engine::BasePlugin {
 
   ~Sleep() = default;
 
-  // public for unit test
-  std::chrono::steady_clock::time_point start_{};
+ private:
+  // Test only
+  friend class TestHelper;
 
-  private:
     int duration_;
+    std::chrono::steady_clock::time_point start_{};
 };
 
 } // namespace Oomd

--- a/src/oomd/plugins/Sleep.h
+++ b/src/oomd/plugins/Sleep.h
@@ -24,8 +24,8 @@ class Sleep : public Engine::BasePlugin {
   // Test only
   friend class TestHelper;
 
-    int duration_;
-    std::chrono::steady_clock::time_point start_{};
+  int duration_;
+  std::chrono::steady_clock::time_point start_{};
 };
 
 } // namespace Oomd

--- a/src/oomd/plugins/Sleep.h
+++ b/src/oomd/plugins/Sleep.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <chrono>
+
+#include "oomd/engine/BasePlugin.h"
+
+namespace Oomd {
+
+class Sleep : public Engine::BasePlugin {
+ public:
+  int init(
+      const Engine::PluginArgs& args,
+      const PluginConstructionContext& context) override;
+
+  Engine::PluginRet run(OomdContext& /* unused */) override;
+
+  static Sleep* create() {
+    return new Sleep();
+  }
+
+  ~Sleep() = default;
+
+  private:
+    int duration_;
+
+    std::chrono::steady_clock::time_point start_{};
+};
+
+} // namespace Oomd

--- a/src/oomd/util/Fs.cpp
+++ b/src/oomd/util/Fs.cpp
@@ -764,6 +764,14 @@ SystemMaybe<Unit> Fs::writeMemhightmpAt(
   return noSystemError();
 }
 
+SystemMaybe<int64_t> Fs::readMemReclaimAt(const DirFd& dirfd) {
+  auto lines = readFileByLine(Fs::Fd::openat(dirfd, kMemReclaimFile));
+  if (!lines) {
+    return SYSTEM_ERROR(lines.error());
+  }
+  return static_cast<int64_t>(std::stoll((*lines)[0]));
+}
+
 SystemMaybe<Unit> Fs::writeMemReclaimAt(
     const DirFd& dirfd,
     int64_t value,

--- a/src/oomd/util/Fs.cpp
+++ b/src/oomd/util/Fs.cpp
@@ -67,7 +67,7 @@ namespace Oomd {
 SystemMaybe<Fs::Fd>
 Fs::Fd::openat(const DirFd& dirfd, const std::string& path, bool read_only) {
   int flags = read_only ? O_RDONLY : O_WRONLY;
-  const auto fd = ::openat(dirfd.fd(), path.c_str(), flags);
+  const auto fd = ::openat(dirfd.fd(), path.c_str(), flags | O_CLOEXEC);
   if (fd == -1) {
     return SYSTEM_ERROR(errno);
   }
@@ -76,7 +76,7 @@ Fs::Fd::openat(const DirFd& dirfd, const std::string& path, bool read_only) {
 
 SystemMaybe<Fs::Fd> Fs::Fd::open(const std::string& path, bool read_only) {
   int flags = read_only ? O_RDONLY : O_WRONLY;
-  const auto fd = ::open(path.c_str(), flags);
+  const auto fd = ::open(path.c_str(), flags | O_CLOEXEC);
   if (fd == -1) {
     return SYSTEM_ERROR(errno);
   }
@@ -99,7 +99,7 @@ void Fs::Fd::close() {
 }
 
 SystemMaybe<Fs::DirFd> Fs::DirFd::open(const std::string& path) {
-  int fd = ::open(path.c_str(), O_RDONLY | O_DIRECTORY);
+  int fd = ::open(path.c_str(), O_RDONLY | O_DIRECTORY | O_CLOEXEC);
   if (fd == -1) {
     return SYSTEM_ERROR(errno);
   }
@@ -107,7 +107,7 @@ SystemMaybe<Fs::DirFd> Fs::DirFd::open(const std::string& path) {
 }
 
 SystemMaybe<Fs::DirFd> Fs::DirFd::openChildDir(const std::string& path) const {
-  int child_fd = ::openat(fd(), path.c_str(), O_RDONLY | O_DIRECTORY);
+  int child_fd = ::openat(fd(), path.c_str(), O_RDONLY | O_DIRECTORY | O_CLOEXEC);
   if (child_fd == -1) {
     return SYSTEM_ERROR(errno);
   }

--- a/src/oomd/util/Fs.h
+++ b/src/oomd/util/Fs.h
@@ -235,6 +235,7 @@ class Fs {
       const DirFd& dirfd,
       int64_t value,
       std::chrono::microseconds duration);
+  static SystemMaybe<int64_t> readMemReclaimAt(const DirFd& dirfd);
   static SystemMaybe<Unit> writeMemReclaimAt(
       const DirFd& dirfd,
       int64_t value,

--- a/src/oomd/util/PluginArgParser.cpp
+++ b/src/oomd/util/PluginArgParser.cpp
@@ -149,6 +149,12 @@ std::chrono::milliseconds PluginArgParser::parseValue(
 }
 
 template <>
+std::chrono::seconds PluginArgParser::parseValue(
+    const std::string& valueString) {
+  return std::chrono::seconds(std::stoll(valueString));
+}
+
+template <>
 ResourceType PluginArgParser::parseValue(const std::string& valueString) {
   if (valueString == "io") {
     return ResourceType::IO;

--- a/src/oomd/util/TestHelper.h
+++ b/src/oomd/util/TestHelper.h
@@ -86,7 +86,7 @@ class TestHelper {
   }
 
   static void dropCgroup(OomdContext& ctx, const CgroupPath& cgroup) {
-    for (auto it = ctx.cgroups_.begin(); it != ctx.cgroups_.end(); )
+    for (auto it = ctx.cgroups_.begin(); it != ctx.cgroups_.end();)
       it = it->first != cgroup ? std::next(it) : ctx.cgroups_.erase(it);
   }
 

--- a/src/oomd/util/TestHelper.h
+++ b/src/oomd/util/TestHelper.h
@@ -21,6 +21,8 @@
 #include "oomd/OomdContext.h"
 #include "oomd/PluginRegistry.h"
 #include "oomd/engine/PrekillHook.h"
+#include "oomd/plugins/Interdict.h"
+#include "oomd/plugins/Sleep.h"
 
 #define ASSERT_EXISTS(opt_expr) \
   ({                            \
@@ -56,6 +58,10 @@ class TestHelper {
     return ctx.cgroups_;
   }
 
+  static void setCurrentTick(OomdContext& ctx, uint64_t x) {
+    ctx.current_tick_ = x;
+  }
+
   /*
    * Set the cgroup data of a CgroupContext in OomdContext.
    * This is a shortcut for setting up CgroupContext without creating control
@@ -77,6 +83,23 @@ class TestHelper {
         cached_ctx.archive_ = *archive;
       }
     }
+  }
+
+  static void dropCgroup(OomdContext& ctx, const CgroupPath& cgroup) {
+    for (auto it = ctx.cgroups_.begin(); it != ctx.cgroups_.end(); )
+      it = it->first != cgroup ? std::next(it) : ctx.cgroups_.erase(it);
+  }
+
+  static std::chrono::steady_clock::time_point getSleepStart(Sleep* s) {
+    return s->start_;
+  }
+
+  static void setSleepStart(Sleep* s, std::chrono::steady_clock::time_point x) {
+    s->start_ = x;
+  }
+
+  static size_t getSavedSize(Interdict* i) {
+    return i->saved_.size();
   }
 };
 

--- a/src/oomd/util/TestHelper.h
+++ b/src/oomd/util/TestHelper.h
@@ -22,6 +22,7 @@
 #include "oomd/PluginRegistry.h"
 #include "oomd/engine/PrekillHook.h"
 #include "oomd/plugins/Interdict.h"
+#include "oomd/plugins/RunCommand.h"
 #include "oomd/plugins/Sleep.h"
 
 #define ASSERT_EXISTS(opt_expr) \
@@ -100,6 +101,10 @@ class TestHelper {
 
   static size_t getSavedSize(Interdict* i) {
     return i->saved_.size();
+  }
+
+  static size_t getArgsSize(RunCommand* r) {
+    return r->c_args_.size();
   }
 };
 


### PR DESCRIPTION
See fork_changes.md in this PR for docs. From the doc:
This branch adds new plugins and makes small changes to the oomd engine to complement them. The new plugins are: sleep, always_reclaim, interdict, and run_command. The engine now supports an exit registry where plugins can add functions to run at oomd exit, an always-continue flag to always run a ruleset's actions which may behave differently when detectors fail to match, and a per-ruleset kill-index section to modify kill targets.