### PR TITLE
Add interval settings from config file and once for run_command

### DIFF
--- a/docs/fork_changes.md
+++ b/docs/fork_changes.md
@@ -2,11 +2,23 @@
 
 This branch adds new plugins and makes small changes to the oomd engine
 to complement them.  The new plugins are: sleep, always_reclaim, interdict,
-and run_command.  The engine now supports an exit registry where plugins
-can add functions to run at oomd exit, an always-continue flag to
-always run a ruleset's actions which may behave differently when detectors
-fail to match, and a per-ruleset kill-index section to modify kill targets.
+and run_command.  The engine now supports:
 
+* polling for config file changes
+  * restarts when a change is detected
+* an exit registry
+  * lets plugins add functions to run at oomd exit
+* an always-continue flag to always run a ruleset's actions
+  * lets plugins respond when detectors fail to match
+* a per-ruleset kill-index
+  * directly specify priorities of kill targets
+
+
+# Config File
+
+The looping interval and config file check interval may be specified either
+by command-line arguments or the top-level config file keys: "interval" and
+"config_interval".  If specified both ways, the config file takes precedence.
 
 # Ruleset
 
@@ -114,6 +126,7 @@ all saved values are written back.
     argument
     use_exit_value
     cache_sec
+    once
     timeout_msec
 
 ### Description
@@ -128,3 +141,6 @@ If `cache_sec`, default 0, is greater than 0 then the plugin returns
 the value from the last run for the duration specified.  If `timeout_msec`,
 default 500 milliseconds, is greater than 0, then a run exceeding the
 timeout is killed.  With `use_exit_value` true, a killed run returns STOP.
+
+With `once` set to true, the plugin runs `command` exactly once,
+caches the result, and returns the cached value for all future calls.

--- a/src/oomd/Main.cpp
+++ b/src/oomd/Main.cpp
@@ -98,7 +98,7 @@ static void printUsage() {
          "  --device DEVS              Comma separated <major>:<minor> pairs for IO cost calculation (default: none)\n"
          "  --ssd-coeffs COEFFS        Comma separated values for SSD IO cost calculation (default: see doc)\n"
          "  --hdd-coeffs COEFFS        Comma separated values for HDD IO cost calculation (default: see doc)\n"
-         "  --kmsg-override PATH       File to log kills to (default: /dev/kmsg)"
+         "  --kmsg-override, -k PATH   File to log kills to (default: /dev/kmsg)"
       << std::endl;
 }
 
@@ -324,7 +324,7 @@ int main(int argc, char** argv) {
           parse_error = true;
         }
         if (parse_error || config_interval < 0 || parsed_len != strlen(optarg)) {
-          std::cerr << "Interval is negative: " << optarg << std::endl;
+          std::cerr << "Config interval not a >-1 integer: " << optarg << std::endl;
           return 1;
         }
         break;
@@ -480,13 +480,23 @@ int main(int argc, char** argv) {
     return EXIT_CANT_RECOVER;
   }
 
-  std::cerr << "oomd running with conf_file=" << flag_conf_file
-            << " interval=" << interval << std::endl;
+  std::cerr << "oomd running with conf_file=" << flag_conf_file << std::endl;
 
   auto ir = parseConfig(flag_conf_file);
   if (!ir) {
     return EXIT_CANT_RECOVER;
   }
+
+  if (ir->interval > -1) {
+    interval = ir->interval;
+  }
+
+  if (ir->config_interval > -1) {
+    config_interval = ir->config_interval;
+  }
+
+  std::cerr << "oomd running with interval=" << interval
+            << " config_interval=" << config_interval << std::endl;
 
   Oomd::PluginConstructionContext compile_context(cgroup_fs);
 

--- a/src/oomd/config/ConfigTypes.cpp
+++ b/src/oomd/config/ConfigTypes.cpp
@@ -27,7 +27,7 @@ namespace {
  * vary because some lines numbers are 3 digits and some are 2.
  */
 Oomd::LogStream::Offset getIndentSpaces(uint64_t depth) {
-  return Oomd::LogStream::Offset{.n = ::strlen(FILENAME) + 7 + depth * 2};
+  return Oomd::LogStream::Offset{.n = ::strlen(FILENAME) + 20 + depth * 2};
 }
 } // namespace
 
@@ -37,6 +37,15 @@ namespace IR {
 
 void dumpIR(const Root& root) {
   int indent = 0;
+
+  if (root.interval > -1) {
+    OLOG << getIndentSpaces(indent) << "interval=" << root.interval;
+  }
+
+  if (root.config_interval > -1) {
+    OLOG << getIndentSpaces(indent) << "config_interval="
+         << root.config_interval;
+  }
 
   // Prekill hooks
   OLOG << getIndentSpaces(indent) << root.prekill_hooks.size()

--- a/src/oomd/config/ConfigTypes.h
+++ b/src/oomd/config/ConfigTypes.h
@@ -79,6 +79,7 @@ struct Ruleset {
 };
 
 struct Root {
+  int interval, config_interval;
   std::vector<Ruleset> rulesets;
   std::vector<PrekillHook> prekill_hooks;
   std::string path;

--- a/src/oomd/config/JsonConfigParser.cpp
+++ b/src/oomd/config/JsonConfigParser.cpp
@@ -157,6 +157,21 @@ Oomd::Config2::IR::Ruleset parseRuleset(const Json::Value& ruleset) {
   return ir_ruleset;
 }
 
+int parseConfigFromJson(const Json::Value& root, const std::string& key, int min) {
+  if (root.isObject() && root.isMember(key)) {
+    const auto& value = root[key];
+    if (value.isNumeric() && value > min) {
+      return value.asInt();
+    } else {
+      OLOG << "Value for " << key << " must be an integer >" << min <<": "
+           << value.asString();
+      throw std::runtime_error("Invalid config");
+    }
+  }
+
+  return -1;
+}
+
 } // namespace
 
 namespace Oomd {
@@ -168,6 +183,8 @@ std::unique_ptr<IR::Root> JsonConfigParser::parse(const std::string& input, cons
   auto ir_root = std::make_unique<IR::Root>();
 
   ir_root->path = std::move(path);
+  ir_root->interval = parseConfigFromJson(json_root, "interval", 0);
+  ir_root->config_interval = parseConfigFromJson(json_root, "config_interval", -1);
 
   for (const auto& ruleset : json_root.get("rulesets", {})) {
     ir_root->rulesets.emplace_back(parseRuleset(ruleset));

--- a/src/oomd/config/JsonConfigParserTest.cpp
+++ b/src/oomd/config/JsonConfigParserTest.cpp
@@ -37,6 +37,13 @@ TEST(JsonConfigParserTest, LoadIR) {
   JsonConfigParser parser;
   auto root = parser.parse(buffer.str(), kConfig_1_0_0);
   ASSERT_TRUE(root);
+  EXPECT_EQ(root->path, kConfig_1_0_0);
+  EXPECT_EQ(root->interval, 60);
+  EXPECT_EQ(root->config_interval, 300);
+  auto root2 = parser.parse("{}", "foo");
+  EXPECT_EQ(root2->path, "foo");
+  EXPECT_EQ(root2->interval, -1);
+  EXPECT_EQ(root2->config_interval, -1);
 
   // Check root values
   ASSERT_EQ(root->rulesets.size(), 2);

--- a/src/oomd/fixtures/oomd.json
+++ b/src/oomd/fixtures/oomd.json
@@ -1,4 +1,6 @@
 {
+    "interval": 60,
+    "config_interval": 300,
     "rulesets": [
         {
             "name": "my first ruleset",

--- a/src/oomd/plugins/CorePluginsTest.cpp
+++ b/src/oomd/plugins/CorePluginsTest.cpp
@@ -3635,16 +3635,32 @@ TEST_F(RunCommandTest , RunCommandCache) {
   EXPECT_EQ(2, WEXITSTATUS(
         std::system("rc=`ls go.* | grep -c .`; rm -f go.*; exit $rc")));
 
-  plugin = createPlugin("run_command");
-  ASSERT_NE(plugin, nullptr);
+  auto plugin2 = createPlugin("run_command");
+  ASSERT_NE(plugin2, nullptr);
 
   args["cache_sec"] = "100";
 
-  ASSERT_EQ(plugin->init(std::move(args), compile_context), 0);
+  ASSERT_EQ(plugin2->init(std::move(args), compile_context), 0);
 
-  EXPECT_EQ(plugin->run(ctx_), Engine::PluginRet::CONTINUE);
-  EXPECT_EQ(plugin->run(ctx_), Engine::PluginRet::CONTINUE);
-  EXPECT_EQ(plugin->run(ctx_), Engine::PluginRet::CONTINUE);
+  EXPECT_EQ(plugin2->run(ctx_), Engine::PluginRet::CONTINUE);
+  EXPECT_EQ(plugin2->run(ctx_), Engine::PluginRet::CONTINUE);
+  EXPECT_EQ(plugin2->run(ctx_), Engine::PluginRet::CONTINUE);
+
+  EXPECT_EQ(1, WEXITSTATUS(
+        std::system("rc=`ls go.* | grep -c .`; rm -f go.*; exit $rc")));
+
+  auto plugin3 = createPlugin("run_command");
+  ASSERT_NE(plugin, nullptr);
+
+  Engine::PluginArgs args3;
+  args3["command"] = tempdir_ + "/go";
+  args3["use_exit_value"] = "true";
+  args3["once"] = "true";
+
+  ASSERT_EQ(plugin3->init(std::move(args3), compile_context), 0);
+
+  EXPECT_EQ(plugin3->run(ctx_), Engine::PluginRet::CONTINUE);
+  EXPECT_EQ(plugin3->run(ctx_), Engine::PluginRet::CONTINUE);
 
   EXPECT_EQ(1, WEXITSTATUS(
         std::system("rc=`ls go.* | grep -c .`; rm -f go.*; exit $rc")));

--- a/src/oomd/plugins/RunCommand.cpp
+++ b/src/oomd/plugins/RunCommand.cpp
@@ -15,6 +15,9 @@ namespace Oomd {
 
 REGISTER_PLUGIN(run_command, RunCommand::create);
 
+using Engine::PluginRet::STOP;
+using Engine::PluginRet::CONTINUE;
+
 int RunCommand::init(
     const Engine::PluginArgs& pluginArgs,
     const PluginConstructionContext& context) {
@@ -23,6 +26,7 @@ int RunCommand::init(
   argParser_.addArgument("command", command_, true);
   argParser_.addArgument("use_exit_value", useExitValue_);
   argParser_.addArgument("cache_sec", cacheSec_);
+  argParser_.addArgument("once", once_);
   argParser_.addArgument("timeout_msec", timeoutMsec_);
   argParser_.addArgument("argument", wholeArg);
 
@@ -78,15 +82,19 @@ SystemMaybe<int> RunCommand::forkexec() {
 }
 
 Engine::PluginRet RunCommand::run(OomdContext& ctx) {
+  if (once_ && ret_) {
+    return ret_.value();  // return quietly - log only the initial execution
+  }
+
   using std::chrono::steady_clock;
 
   const auto now = steady_clock::now();
   const auto diff =
       std::chrono::duration_cast<std::chrono::seconds>(now - start_).count();
   if (diff < cacheSec_) {
-    const auto s = ret_ == Engine::PluginRet::CONTINUE ? "CONTINUE" : "STOP";
+    const auto s = ret_ == CONTINUE ? "CONTINUE" : "STOP";
     OLOG << "using cached result; diff=" << diff << " ret=" << s;
-    return ret_; // Skip execution if within cache time
+    return ret_.value(); // Skip execution if within cache time
   }
 
   start_ = now;
@@ -94,18 +102,18 @@ Engine::PluginRet RunCommand::run(OomdContext& ctx) {
   const auto maybe = forkexec();
   if (!maybe) {
     OLOG << maybe.error().what();
-    return ret_ = useExitValue_ ? Engine::PluginRet::STOP
-                                : Engine::PluginRet::CONTINUE;
+    ret_ = useExitValue_ ? STOP : CONTINUE;
+    return ret_.value();
   }
 
   ret_ = useExitValue_ && (!WIFEXITED(*maybe) || WEXITSTATUS(*maybe) != 0)
-      ? Engine::PluginRet::STOP // Non-zero exit value or killed
-      : Engine::PluginRet::CONTINUE;
+      ? STOP // Non-zero exit value or killed
+      : CONTINUE;
 
-  const auto s = ret_ == Engine::PluginRet::CONTINUE ? "CONTINUE" : "STOP";
+  const auto s = ret_ == CONTINUE ? "CONTINUE" : "STOP";
   OLOG << "use_exit_value=" << useExitValue_ << " status=" << *maybe
        << " exit=" << WEXITSTATUS(*maybe) << " ret=" << s;
-  return ret_;
+  return ret_.value();
 }
 
 } // namespace Oomd

--- a/src/oomd/plugins/RunCommand.h
+++ b/src/oomd/plugins/RunCommand.h
@@ -28,10 +28,11 @@ class RunCommand : public Engine::BasePlugin {
 
   std::string command_;
   int64_t cacheSec_{0}; // Default to no caching
+  bool once_{false};
   std::chrono::milliseconds timeoutMsec_{std::chrono::milliseconds(500)};
   bool useExitValue_{false};
   std::chrono::time_point<std::chrono::steady_clock> start_{};
-  Engine::PluginRet ret_;
+  std::optional<Engine::PluginRet> ret_;
   std::vector<std::string> args_;
   std::vector<char*> c_args_;
 };


### PR DESCRIPTION
This PR allows 2 command-line arguments to be set via the config file.  This complements deploying the ruleset config file separately from the program and the built-in restarts.  The `run_command` plugin now supports a one-time-only execution allowing a ruleset to be targeted based on the context of the node.